### PR TITLE
Implement some kind of popup protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ left out of this section.
   * **NOT SUPPORTED.** See [#101](https://github.com/citp/OpenWPM/issues/101).
   * Set to `True` to enable Firefox's built-in
     [Tracking Protection](https://developer.mozilla.org/en-US/Firefox/Privacy/Tracking_Protection).
+* `no-popups`
+  * Set to `True` to disable popups (or new windows/tabs) by for example clicking on a link that would open in a new window or tab.
 
 Browser Profile Support
 -----------------------

--- a/automation/DeployBrowsers/configure_firefox.py
+++ b/automation/DeployBrowsers/configure_firefox.py
@@ -86,6 +86,11 @@ def privacy(browser_params, fp, fo, root_dir, browser_profile_path):
         shutil.copy(os.path.join(root_dir, 'firefox_extensions',
                                  'ublock_origin', 'storage.js'), ublock_dir)
 
+    if browser_params['no-popups']:
+        # Disable popups
+        fo.set_preference("browser.link.open_newwindow.restriction", 0)
+        fo.set_preference("browser.link.open_newwindow", 1)
+
 
 def optimize_prefs(fo):
     """

--- a/automation/default_browser_params.json
+++ b/automation/default_browser_params.json
@@ -23,5 +23,6 @@
     "https-everywhere": false,
     "adblock-plus": false,
     "ublock-origin": false,
-    "tracking-protection": false
+    "tracking-protection": false,
+    "no-popups": false
 }


### PR DESCRIPTION
When 'no-popups' in the browser-configuration is set to true, websites cannot open a new tab or window by for example setting a link target to '_blank' or a similar method. This is useful when you wanna make sure that all actions happen only inside a single tab and window.

This can also be archived using the current codebase and setting additional preferences, this patch makes it just more convenient for the user.