### PR TITLE
Set daemon to false to fix the socketio server

### DIFF
--- a/automation/BrowserManager.py
+++ b/automation/BrowserManager.py
@@ -136,7 +136,7 @@ class Browser:
             args = (self.command_queue, self.status_queue, self.browser_params,
                     self.manager_params, crash_recovery)
             self.browser_manager = Process(target=BrowserManager, args=args)
-            self.browser_manager.daemon = True
+            self.browser_manager.daemon = False
             self.browser_manager.start()
 
             # Read success status of browser manager


### PR DESCRIPTION
Sets the daemon flag of the BrowserManager process to false. Daemon processes in python cannot have childs and the BrowserManager tries to fork a new child process when starting the socketio server.