### PR TITLE
Fix the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN sed -i'' 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.list
 RUN apt-get clean -y && rm -r /var/lib/apt/lists/* -vf && apt-get clean -y && apt-get update -y && apt-get upgrade -y && apt-get install sudo -y
 
-# For some reasons, the build-extension.sh script does not work as root. We create another user and allow him to run sudo without a password. Then we run the install.sh script as openwpm, which calls build-extension.sh.
+# The build-extension.sh script does not work as root. We create another user and allow it to run sudo without a password. Then we run the install.sh script as openwpm, which calls build-extension.sh.
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers; adduser --disabled-password --gecos "OpenWPM"  openwpm; adduser  openwpm sudo
 RUN chown -R openwpm.openwpm .; su openwpm -c "./install.sh --no-flash"; chown -R root.root .
 CMD python demo.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,8 @@ COPY . /app
 WORKDIR /app
 RUN sed -i'' 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.list
 RUN apt-get clean -y && rm -r /var/lib/apt/lists/* -vf && apt-get clean -y && apt-get update -y && apt-get upgrade -y && apt-get install sudo -y
-RUN ./install.sh --no-flash
+
+# For some reasons, the build-extension.sh script does not work as root. We create another user and allow him to run sudo without a password. Then we run the install.sh script as openwpm, which calls build-extension.sh.
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers; adduser --disabled-password --gecos "OpenWPM"  openwpm; adduser  openwpm sudo
+RUN chown -R openwpm.openwpm .; su openwpm -c "./install.sh --no-flash"; chown -R root.root .
 CMD python demo.py


### PR DESCRIPTION
For some reasons, the build-extension.sh script does not work as root. This can be fixed by creating an openwpm user with sudo permissions and run the install.sh script as openwpm.

Currently, the openwpm user remains in the image, but the Dockerfile could also be changed to remove the user after the build again.

Once this is merged, I would also recommend to merge https://github.com/mozilla/OpenWPM/pull/270 since that adds the Dockerfile to the travis-ci build.