### PR TITLE
Fix PEP8 Errors on python2 caused by ConnectionAbortedError

### DIFF
--- a/automation/SocketInterface.py
+++ b/automation/SocketInterface.py
@@ -12,8 +12,9 @@ from six.moves import input
 from six.moves.queue import Queue
 
 if six.PY2:
-    class ConnectionAbortedError(Exception):
-        pass
+    ConnectionAbortedException = socket.error
+else:
+    ConnectionAbortedException = ConnectionAbortedError
 
 # TODO - Implement a cleaner shutdown for server socket
 # see: https://stackoverflow.com/a/1148237
@@ -51,7 +52,7 @@ class serversocket:
                                           args=(client, address))
                 thread.daemon = True
                 thread.start()
-            except ConnectionAbortedError:
+            except ConnectionAbortedException:
                 # Workaround for #278
                 print("A connection establish request was performed " +
                       "on a closed socket")

--- a/automation/SocketInterface.py
+++ b/automation/SocketInterface.py
@@ -12,9 +12,8 @@ from six.moves import input
 from six.moves.queue import Queue
 
 if six.PY2:
-    ConnectionAbortedException = socket.error
-else:
-    ConnectionAbortedException = ConnectionAbortedError
+    class ConnectionAbortedError(Exception):
+        pass
 
 # TODO - Implement a cleaner shutdown for server socket
 # see: https://stackoverflow.com/a/1148237
@@ -52,7 +51,7 @@ class serversocket:
                                           args=(client, address))
                 thread.daemon = True
                 thread.start()
-            except ConnectionAbortedException:
+            except ConnectionAbortedError:
                 # Workaround for #278
                 print("A connection establish request was performed " +
                       "on a closed socket")

--- a/automation/SocketInterface.py
+++ b/automation/SocketInterface.py
@@ -7,8 +7,13 @@ import threading
 import traceback
 
 import dill
+import six
 from six.moves import input
 from six.moves.queue import Queue
+
+if six.PY2:
+    class ConnectionAbortedError(Exception):
+        pass
 
 # TODO - Implement a cleaner shutdown for server socket
 # see: https://stackoverflow.com/a/1148237


### PR DESCRIPTION
This exception is not defined in 2.7. From my testing, there doesn't seem to be an alternate exception thrown on MacOS so the best option seems to be to define a dummy exception.