### PR TITLE
Run autopep8 to fix errors not flagged by flake8

### DIFF
--- a/automation/BrowserManager.py
+++ b/automation/BrowserManager.py
@@ -35,6 +35,7 @@ class Browser:
      <browser_params> are per-browser parameter settings (e.g. whether
                       this browser is headless, etc.)
      """
+
     def __init__(self, manager_params, browser_params):
         # Constants
         self._SPAWN_TIMEOUT = 120  # seconds

--- a/automation/DataAggregator/LocalAggregator.py
+++ b/automation/DataAggregator/LocalAggregator.py
@@ -50,6 +50,7 @@ def listener_process_runner(
 
 class LocalListener(BaseListener):
     """Listener that interfaces with a local SQLite database."""
+
     def __init__(
             self, status_queue, shutdown_queue, manager_params, ldb_enabled):
         db_path = manager_params['database_name']
@@ -180,6 +181,7 @@ class LocalAggregator(BaseAggregator):
 
     If content saving is enabled, we write page content to a LevelDB database.
     """
+
     def __init__(self, manager_params, browser_params):
         super(LocalAggregator, self).__init__(manager_params, browser_params)
         db_path = self.manager_params['database_name']

--- a/automation/DataAggregator/S3Aggregator.py
+++ b/automation/DataAggregator/S3Aggregator.py
@@ -53,6 +53,7 @@ class S3Listener(BaseListener):
     a parquet dataset. The schema for this dataset is given in
     ./parquet_schema.py
     """
+
     def __init__(
             self, status_queue, shutdown_queue, manager_params, instance_id):
         self.dir = manager_params['s3_directory']
@@ -275,6 +276,7 @@ class S3Aggregator(BaseAggregator):
     columns up to 32 bits. Currently, `instance_id` is the only partition
     column, and thus can be no larger than 32 bits.
     """
+
     def __init__(self, manager_params, browser_params):
         super(S3Aggregator, self).__init__(manager_params, browser_params)
         self.dir = manager_params['s3_directory']

--- a/automation/DeployBrowsers/selenium_firefox.py
+++ b/automation/DeployBrowsers/selenium_firefox.py
@@ -57,6 +57,7 @@ class FirefoxLogInterceptor(threading.Thread):
     instance.  Also responsible for extracting the _real_ profile location
     from geckodriver's log output (geckodriver copies the profile).
     """
+
     def __init__(self, crawl_id, logger, profile_path):
         threading.Thread.__init__(self, name="log-interceptor-%i" % crawl_id)
         self.crawl_id = crawl_id
@@ -138,6 +139,7 @@ FirefoxDriverModule.Service = PatchedGeckoDriverService
 
 class FirefoxProfile(BaseFirefoxProfile):
     """Hook class for patching bugs in Selenium's FirefoxProfile class"""
+
     def __init__(self, *args, **kwargs):
         BaseFirefoxProfile.__init__(self, *args, **kwargs)
 

--- a/automation/Errors.py
+++ b/automation/Errors.py
@@ -3,6 +3,7 @@
 
 class CommandExecutionError(Exception):
     """ Raise for errors related to executing commands """
+
     def __init__(self, message, command, *args):
         self.message = message
         self.command = command
@@ -11,6 +12,7 @@ class CommandExecutionError(Exception):
 
 class ProfileLoadError(Exception):
     """ Raise for errors that occur while loading profile """
+
     def __init__(self, message, *args):
         self.message = message
         super(ProfileLoadError, self).__init__(message, *args)
@@ -18,6 +20,7 @@ class ProfileLoadError(Exception):
 
 class BrowserConfigError(Exception):
     """ Raise for errors that occur from a misconfiguration of the browser """
+
     def __init__(self, message, *args):
         self.message = message
         super(BrowserConfigError, self).__init__(message, *args)
@@ -25,6 +28,7 @@ class BrowserConfigError(Exception):
 
 class BrowserCrashError(Exception):
     """ Raise for non-critical crashes within the BrowserManager process """
+
     def __init__(self, message, *args):
         self.message = message
         super(BrowserCrashError, self).__init__(message, *args)

--- a/automation/MPLogger.py
+++ b/automation/MPLogger.py
@@ -18,6 +18,7 @@ class ClientSocketHandler(logging.handlers.SocketHandler):
     """
     Make SocketHandler compatible with SocketInterface.py
     """
+
     def makePickle(self, record):
         """
         Serializes the record via json and prepends a length/serialization
@@ -26,7 +27,7 @@ class ClientSocketHandler(logging.handlers.SocketHandler):
         ei = record.exc_info
         if ei:
             # just to get traceback text into record.exc_text ...
-            dummy = self.format(record) # noqa
+            dummy = self.format(record)  # noqa
             record.exc_info = None  # to avoid Unpickleable error
         d = dict(record.__dict__)
         d['msg'] = record.getMessage()

--- a/automation/SocketInterface.py
+++ b/automation/SocketInterface.py
@@ -19,6 +19,7 @@ class serversocket:
     A server socket to receive and process string messages
     from client sockets to a central queue
     """
+
     def __init__(self, name=None, verbose=False):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.bind(('localhost', 0))
@@ -111,6 +112,7 @@ class serversocket:
 
 class clientsocket:
     """A client socket for sending messages"""
+
     def __init__(self, serialization='json', verbose=False):
         """ `serialization` specifies the type of serialization to use for
         non-string messages. Supported formats:

--- a/automation/utilities/Cookie.py
+++ b/automation/utilities/Cookie.py
@@ -688,6 +688,7 @@ class SimpleCookie(BaseCookie):
     calls the builtin str() to convert the value to a string.  Values
     received from HTTP are kept as strings.
     """
+
     def value_decode(self, val):
         return _unquote(val), val
 
@@ -711,6 +712,7 @@ class SerialCookie(BaseCookie):
     Note: HTTP has a 2k limit on the size of a cookie.  This class
     does not check for this limit, so be careful!!!
     """
+
     def __init__(self, input=None):
         warnings.warn("SerialCookie class is insecure; do not use it",
                       DeprecationWarning)
@@ -739,6 +741,7 @@ class SmartCookie(BaseCookie):
     Note: HTTP has a 2k limit on the size of a cookie.  This class
     does not check for this limit, so be careful!!!
     """
+
     def __init__(self, input=None):
         warnings.warn("Cookie/SmartCookie class is insecure; do not use it",
                       DeprecationWarning)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [isort]
 known_future_library = future
-known_first_party = automation,openwpmtest
+known_first_party = automation,openwpmtest,test
 default_section = THIRDPARTY
-skip = venv,automation/Extension
+skip = venv,automation/Extension,firefox-bin
 
 [flake8]
 exclude = venv,automation/Extension,firefox-bin

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -31,7 +31,7 @@ HTTP_REQUESTS = {
         u'undefined',
         u'undefined',
         0, 0, 1, None, None, u'main_frame',
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_favicon.ico',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -39,7 +39,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'image',
-     ),
+    ),
     # (
     #     u'http://localtest.me:8000/test_pages/shared/test_favicon.ico',
     #     u'undefined',
@@ -55,7 +55,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'image',
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_script_2.js',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -63,7 +63,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'script',
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_script.js',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -71,7 +71,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'script',
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_image.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -79,7 +79,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'image',
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -87,7 +87,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 1, 0, None, None, u'sub_frame',
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_style.css',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -95,7 +95,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'stylesheet',
-     ),
+    ),
     (
         u'http://localtest.me:8000/404.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -103,7 +103,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/frame1.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -111,7 +111,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/frame2.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -119,7 +119,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/req1.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -127,7 +127,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/req2.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -135,7 +135,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/req3.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -143,7 +143,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_image_2.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -151,7 +151,7 @@ HTTP_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'image'
-     ),
+    ),
 }
 
 # format: (request_url, referrer, location)
@@ -222,7 +222,7 @@ HTTP_CACHED_REQUESTS = {
         u'undefined',
         u'undefined',
         0, 0, 1, None, None, u'main_frame'
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_script_2.js',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -230,7 +230,7 @@ HTTP_CACHED_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'script'
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_script.js',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -238,7 +238,7 @@ HTTP_CACHED_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'script',
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -246,7 +246,7 @@ HTTP_CACHED_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 1, 0, None, None, u'sub_frame'
-     ),
+    ),
     (
         u'http://localtest.me:8000/test_pages/shared/test_style.css',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -254,7 +254,7 @@ HTTP_CACHED_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'stylesheet'
-     ),
+    ),
     (
         u'http://localtest.me:8000/404.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -262,7 +262,7 @@ HTTP_CACHED_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/frame1.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -270,7 +270,7 @@ HTTP_CACHED_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/frame2.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -278,7 +278,7 @@ HTTP_CACHED_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page_2.html',
         0, 0, 0, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/req1.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
@@ -294,7 +294,7 @@ HTTP_CACHED_REQUESTS = {
         u'http://localtest.me:8000',
         u'http://localtest.me:8000/test_pages/http_test_page.html',
         0, 0, 1, None, None, u'image'
-     ),
+    ),
     (
         u'http://localtest.me:8000/MAGIC_REDIRECT/req3.png',
         u'http://localtest.me:8000/test_pages/http_test_page.html',

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -71,6 +71,7 @@ class MyHandler(SimpleHTTPRequestHandler):
     If a request is made the to `/MAGIC_REDIRECT/` path without a
     `dst` parameter defined, a `404` response is returned.
     """
+
     def __init__(self, *args, **kwargs):
         SimpleHTTPRequestHandler.__init__(self, *args, **kwargs)
 


### PR DESCRIPTION
Running autopep8 on a clean branch which has no other pep8 errors. This should allow for cleaner diffs if someone decides to use autopep8 for a future PR.

Also note that I updated the isort config with some additional context.