### PR TITLE
Use base64 encoding for the response body

### DIFF
--- a/automation/DataAggregator/LocalAggregator.py
+++ b/automation/DataAggregator/LocalAggregator.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 
+import base64
 import json
 import os
 import sqlite3
@@ -129,8 +130,7 @@ class LocalListener(BaseListener):
                 "Attempted to save page content but the LevelDB content "
                 "database is not enabled.")
         content, content_hash = record[1]
-        if isinstance(content, six.text_type):
-            content = str(content).encode('utf-8')
+        content = base64.b64decode(content)
         content_hash = str(content_hash).encode('ascii')
         if self.ldb.get(content_hash) is not None:
             return

--- a/automation/DataAggregator/S3Aggregator.py
+++ b/automation/DataAggregator/S3Aggregator.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 
+import base64
 import gzip
 import hashlib
 import json
@@ -248,6 +249,7 @@ class S3Listener(BaseListener):
                     RECORD_TYPE_CONTENT, record[0])
             )
         content, content_hash = record[1]
+        content = base64.b64decode(content)
         fname = "%s/%s/%s.gz" % (self.dir, CONTENT_DIRECTORY, content_hash)
         self._write_str_to_s3(content, fname)
 

--- a/automation/Extension/firefox/feature.js/loggingdb.js
+++ b/automation/Extension/firefox/feature.js/loggingdb.js
@@ -164,11 +164,30 @@ export let saveContent = async function(content, contentHash) {
     console.log("LDB contentHash:",contentHash,"with length",content.length);
     return;
   }
-  dataAggregator.send(JSON.stringify(['page_content', [content, contentHash]]));
+  // Since the content might not be a valid utf8 string and it needs to be
+  // json encoded later, it is encoded using base64 first.
+  const b64 = Uint8ToBase64(content);
+  dataAggregator.send(JSON.stringify(['page_content', [b64, contentHash]]));
 };
 
 function encode_utf8(s) {
   return unescape(encodeURIComponent(s));
+}
+
+// Base64 encoding, found on:
+// https://stackoverflow.com/questions/12710001/how-to-convert-uint8-array-to-base64-encoded-string/25644409#25644409
+function Uint8ToBase64(u8Arr){
+  var CHUNK_SIZE = 0x8000; //arbitrary number
+  var index = 0;
+  var length = u8Arr.length;
+  var result = '';
+  var slice;
+  while (index < length) {
+    slice = u8Arr.subarray(index, Math.min(index + CHUNK_SIZE, length));
+    result += String.fromCharCode.apply(null, slice);
+    index += CHUNK_SIZE;
+  }
+  return btoa(result);
 }
 
 export let escapeString = function(string) {

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -611,8 +611,7 @@ class TestHTTPInstrument(OpenWPMTest):
             with open(os.path.join(BASE_PATH, path[1:]), 'rb') as f:
                 content = f.read()
             chash = sha256(content).hexdigest()
-            # TODO: webext instrumentation doesn't save the content_hash yet.
-            # assert chash == row['content_hash']
+            assert chash == row['content_hash']
             disk_content[chash] = content
 
         ldb_content = dict()


### PR DESCRIPTION
The response body might contain binary content that cannot be correctly represented by a string. This patch assumes that the openwpm-webext-instrumentation returns the response body as an Uint8Array instead of a string. It is then encoded using base64 to make it string-safe and then send to the DataAggregator of OpenWPM to be saved in a database there.

This patch needs a change in openwpm-webext-instrumentation which is currently not available in the official repository. As long as mozilla/openwpm-webext-instrumentation#45 has not been merged, the patch will not work correctly.