### PR TITLE
Handle HTTP POST requests with raw form data

### DIFF
--- a/automation/DataAggregator/parquet_schema.py
+++ b/automation/DataAggregator/parquet_schema.py
@@ -83,6 +83,7 @@ fields = [
     pa.field('req_call_stack', pa.string()),
     pa.field('resource_type', pa.string(), nullable=False),
     pa.field('post_body', pa.string()),
+    pa.field('post_body_raw', pa.string()),
     pa.field('time_stamp', pa.string(), nullable=False),
 ]
 PQ_SCHEMAS['http_requests'] = pa.schema(fields)

--- a/automation/schema.sql
+++ b/automation/schema.sql
@@ -105,6 +105,7 @@ CREATE TABLE IF NOT EXISTS http_requests(
   req_call_stack TEXT,
   resource_type TEXT NOT NULL,
   post_body TEXT,
+  post_body_raw TEXT,
   time_stamp DATETIME NOT NULL
 );
 


### PR DESCRIPTION
A recent version of openwpm-webext-instrumentation also supports HTTP
POST request in which the POST body is only available as raw binary
data that is stored in the post_body_raw column.

This change updates the database structure with that column and adjusts
the tests so that those cases are correctly tested.

Before this can be merged, https://github.com/mozilla/openwpm-webext-instrumentation/pull/47 needs to be merged.