### PR TITLE
Mozilla rmjquery raw post

### DIFF
--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -693,15 +693,16 @@ class TestPOSTInstrument(OpenWPMTest):
         """Test AJAX payloads that are not in the key=value form."""
         post_format = "noKeyValue"
         db = self.visit("/post_request_ajax.html?format=" + post_format)
-        post_body = self.get_post_request_body_from_db(db)
-        assert post_body == "test@example.com + name surname"
+        post_body = self.get_post_request_body_from_db(db, True)
+        assert post_body.decode('utf8') == "test@example.com + name surname"
 
     def test_record_post_data_ajax_no_key_value_base64_encoded(self):
         """Test Base64 encoded AJAX payloads (no key=value form)."""
         post_format = "noKeyValueBase64"
         db = self.visit("/post_request_ajax.html?format=" + post_format)
-        post_body = self.get_post_request_body_from_db(db)
-        assert post_body == "dGVzdEBleGFtcGxlLmNvbSArIG5hbWUgc3VybmFtZQ=="
+        post_body = self.get_post_request_body_from_db(db, True)
+        assert post_body.decode('utf8') == (
+            "dGVzdEBleGFtcGxlLmNvbSArIG5hbWUgc3VybmFtZQ==")
 
     def test_record_post_formdata(self):
         post_format = "formData"

--- a/test/test_pages/post_request_ajax.html
+++ b/test/test_pages/post_request_ajax.html
@@ -8,14 +8,18 @@
     <script type="text/javascript" src="shared/utils.js"></script>
     <script type="application/javascript">
 
+      function do_xhr(data) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", "bogus_submit.html");
+        xhr.send(data);
+      }
+
 	    function send_form_data() {
 	      // Use "FormData"
 	      var formData = new FormData();
 	      formData.append("email", "test@example.com");
 	      formData.append("username", "name surname+");
-	      var request = new XMLHttpRequest();
-	      request.open("POST", "/bogus_submit");
-	      request.send(formData);
+	      do_xhr(formData);
 	    }
 
 	    function send_binary_data(){
@@ -27,9 +31,7 @@
 	        longInt8View[i] = i % 255;
 	      }
 
-	      var xhr = new XMLHttpRequest;
-	      xhr.open("POST", "ajax_post.html", false);
-	      xhr.send(myArray);
+        do_xhr(myArray);
 	    }
 
       $(document).ready(function(){
@@ -40,9 +42,9 @@
           var post_obj = {email:"test@example.com", username:"name surname+"};
           $.post("bogus_submit.html", post_obj);
         } else if (format == "noKeyValue") {
-          $.post("bogus_submit.html", 'test@example.com + name surname', null, "text");
+          do_xhr('test@example.com + name surname');
         } else if (format == "noKeyValueBase64") {
-          $.post("bogus_submit.html", btoa('test@example.com + name surname'), null, "text");
+          do_xhr(btoa('test@example.com + name surname'));
         } else if (format == "binary") {
           send_binary_data();
         }


### PR DESCRIPTION
This is an updated PR for https://github.com/mozilla/OpenWPM/pull/311

In a nutshell, the code in the previous PR was correct, but the post body was considered to be "raw" by Firefox, so it only works when https://github.com/mozilla/OpenWPM/pull/315 has been merged.

This PR includes https://github.com/mozilla/OpenWPM/pull/315, otherwise it would not work.