### PR TITLE
Fix test_js_profile_cookies

### DIFF
--- a/test/test_storage_vectors.py
+++ b/test/test_storage_vectors.py
@@ -22,12 +22,19 @@ expected_lso_content_b = [
     u'REPLACEME']
 
 expected_js_cookie = (
-    1,  # visit id
-    u'%s' % utilities.BASE_TEST_URL_DOMAIN,
-    u'test_cookie',
-    u'Test-0123456789',
-    u'%s' % utilities.BASE_TEST_URL_DOMAIN,
-    u'/')
+    1,                                       # visit_id
+    u'added-or-changed',                     # record_type
+    u'explicit',                             # change_cause
+    0,                                       # is_http_only
+    1,                                       # is_host_only
+    0,                                       # is_session
+    u'%s' % utilities.BASE_TEST_URL_DOMAIN,  # host
+    0,                                       # is_secure
+    u'test_cookie',                          # name
+    u'/',                                    # path
+    u'Test-0123456789',                      # value
+    u'no_restriction'                        # same_site
+)
 
 
 class TestStorageVectors(OpenWPMTest):
@@ -110,20 +117,22 @@ class TestStorageVectors(OpenWPMTest):
         """ Check that profile cookies set by JS are saved """
         # Run the test crawl
         manager_params, browser_params = self.get_config()
+        browser_params[0]['cookie_instrument'] = True
         manager = TaskManager.TaskManager(manager_params, browser_params)
         url = utilities.BASE_TEST_URL + "/js_cookie.html"
         cs = CommandSequence.CommandSequence(url)
         cs.get(sleep=3, timeout=120)
-        cs.dump_profile_cookies()
         manager.execute_command_sequence(cs)
         manager.close()
         # Check that the JS cookie we stored is recorded
         qry_res = db_utils.query_db(
-            manager_params['db'],
-            "SELECT * FROM profile_cookies",
+            manager_params['db'], (
+                "SELECT visit_id, record_type, change_cause, is_http_only, "
+                "is_host_only, is_session, host, is_secure, name, path, "
+                "value, same_site FROM javascript_cookies"),
             as_tuple=True
         )
         assert len(qry_res) == 1  # we store only one cookie
         cookies = qry_res[0]  # take the first cookie
         # compare URL, domain, name, value, origin, path
-        assert cookies[2:8] == expected_js_cookie
+        assert cookies == expected_js_cookie


### PR DESCRIPTION
Previously, test_js_profile_cookies used _dump_profile_cookies_ which dumps the Firefox internal SQLite database to a table. This doesn't work very well anymore in the current version of Firefox and OpenWPM. Instead, the new extension provides a _javascript_cookies_ table that is filled with the cookies when _cookie_instrument_ is set to true. This commit updates the test so that the new table is used now and checks whether a cookie set by JavaScript is correctly recorded there.