### PR TITLE
Remove dump_profile_cookies command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,10 @@ available [below](#output-format).
     * NOTE: Flash cookies are shared across browsers, so this instrumentation
         will not correctly attribute flash cookie changes if more than 1
         browser is running on the machine.
-* Cookie Access (*Experimental* -- Needs tests)
+* Cookie Access
     * Set `browser_params['cookie_instrument'] = True`
     * Data is saved to the `javascript_cookies` table.
     * Will record cookies set both by Javascript and via HTTP Responses
-* Cookie Access (Alternate)
-    * Recorded by scanning the `cookies.sqlite` database in the Firefox profile
-        directory.
-    * Should contain both cookies added by Javascript and by HTTP Responses
-    * To enable: call the `CommandSequence::dump_profile_cookies` command after
-        a page visit. Note that calling this command will close the current tab
-        before recording the cookie changes.
-    * Data is saved to the `profile_cookies` table
 * Log Files
     * Stored in the directory specified by `manager_params['data_directory']`.
     * Name specified by `manager_params['log_file']`.
@@ -329,7 +321,7 @@ manager = TaskManager.TaskManager(manager_params, browser_params)
 for site in sites:
     command_sequence = CommandSequence.CommandSequence(site, reset=True)
     command_sequence.get(sleep=30, timeout=60)
-    command_sequence.dump_profile_cookies(120)
+    command_sequence.dump_flash_cookies(120)
     manager.execute_command_sequence(command_sequence)
 ```
 

--- a/automation/CommandSequence.py
+++ b/automation/CommandSequence.py
@@ -11,16 +11,16 @@ class CommandSequence:
 
     sequence = CommandSequence(url)
     sequence.get()
-    sequence.dump_profile_cookies()
+    sequence.save_screenshot()
     task_manager.execute_command_sequence(sequence)
 
     CommandSequence guarantees that a series of commands will be performed
     by a single browser instance.
 
-    NOTE: Commands dump_profile_cookies and dump_flash_cookies will close
+    NOTE: Command dump_flash_cookies will close
     the current tab - any command that relies on the page still being open,
     like save_screenshot, extract_links, or dump_page_source, should be
-    called prior to one of those two commands.
+    called prior to that.
     """
 
     def __init__(self, url, reset=False, blocking=False):
@@ -65,17 +65,6 @@ class CommandSequence:
                 "No get or browse request preceding "
                 "the dump storage vectors command", self)
         command = ('DUMP_FLASH_COOKIES',)
-        self.commands_with_timeout.append((command, timeout))
-
-    def dump_profile_cookies(self, timeout=60):
-        """ dumps from the profile path to a given file (absolute path)
-        Side effect: closes the current tab."""
-        self.total_timeout += timeout
-        if not self.contains_get_or_browse:
-            raise CommandExecutionError(
-                "No get or browse request preceding "
-                "the dump storage vectors command", self)
-        command = ('DUMP_PROFILE_COOKIES',)
         self.commands_with_timeout.append((command, timeout))
 
     def dump_profile(self, dump_folder, close_webdriver=False,

--- a/automation/Commands/browser_commands.py
+++ b/automation/Commands/browser_commands.py
@@ -20,7 +20,6 @@ from six.moves import range
 
 from ..MPLogger import loggingclient
 from ..SocketInterface import clientsocket
-from .utils.firefox_profile import get_cookies
 from .utils.lso import get_flash_cookies
 from .utils.webdriver_extensions import (execute_in_all_frames,
                                          execute_script_with_retry,
@@ -198,36 +197,6 @@ def dump_flash_cookies(start_time, visit_id, webdriver, browser_params,
         data["crawl_id"] = browser_params["crawl_id"]
         data["visit_id"] = visit_id
         sock.send(("flash_cookies", data))
-
-    # Close connection to db
-    sock.close()
-
-
-def dump_profile_cookies(start_time, visit_id, webdriver,
-                         browser_params, manager_params):
-    """ Save changes to Firefox's cookies.sqlite to database
-
-    We determine which cookies to save by the `start_time` timestamp.
-    This timestamp should be taken prior to calling the `get` for
-    which creates these changes.
-
-    Note that the extension's cookieInstrument is preferred to this approach,
-    as this is likely to miss changes still present in the sqlite `wal` files.
-    This will likely be removed in a future version.
-    """
-    # Set up a connection to DataAggregator
-    tab_restart_browser(webdriver)  # kills window to avoid stray requests
-    sock = clientsocket()
-    sock.connect(*manager_params['aggregator_address'])
-
-    # Cookies
-    rows = get_cookies(browser_params['profile_path'], start_time)
-    if rows is not None:
-        for row in rows:
-            data = dict(row)
-            data["crawl_id"] = browser_params['crawl_id']
-            data["visit_id"] = visit_id
-            sock.send(("profile_cookies", data))
 
     # Close connection to db
     sock.close()

--- a/automation/Commands/command_executor.py
+++ b/automation/Commands/command_executor.py
@@ -27,12 +27,6 @@ def execute_command(command, webdriver, browser_settings, browser_params,
             webdriver=webdriver, browser_params=browser_params,
             manager_params=manager_params)
 
-    if command[0] == 'DUMP_PROFILE_COOKIES':
-        browser_commands.dump_profile_cookies(
-            start_time=command[1], visit_id=command[2],
-            webdriver=webdriver, browser_params=browser_params,
-            manager_params=manager_params)
-
     if command[0] == 'DUMP_PROF':
         profile_commands.dump_profile(
             browser_profile_folder=browser_params['profile_path'],

--- a/automation/Commands/utils/firefox_profile.py
+++ b/automation/Commands/utils/firefox_profile.py
@@ -3,10 +3,8 @@
 from __future__ import absolute_import, print_function
 
 import os
-import sqlite3
 import time
 from glob import glob
-from shutil import copy2
 
 
 def tmp_sqlite_files_exist(path):
@@ -24,39 +22,3 @@ def sleep_until_sqlite_checkpoint(profile_dir, timeout=60):
         time.sleep(1)
         timeout -= 1
     print("Waited for %s seconds for sqlite checkpointing" % (60 - timeout))
-
-
-def get_localStorage(profile_directory, mod_since):
-    # TODO how to support modified since???
-    ff_ls_file = os.path.join(profile_directory, 'webappsstore.sqlite')
-    if not os.path.isfile(ff_ls_file):
-        print("Cannot find localstorage DB %s" % ff_ls_file)
-    else:
-        conn = sqlite3.connect(ff_ls_file)
-        with conn:
-            cur = conn.cursor()
-            cur.execute('SELECT scope, KEY, value \
-                    FROM webappsstore2 \
-                    WHERE last;')
-            rows = cur.fetchall()
-        return rows
-
-
-def get_cookies(profile_directory, mod_since):
-    cookie_db = os.path.join(profile_directory, 'cookies.sqlite')
-    if not os.path.isfile(cookie_db):
-        print("cannot find cookie.db", cookie_db)
-    else:
-        cookie_db_copy = os.path.join(profile_directory, 'cookies_copy.sqlite')
-        copy2(cookie_db, cookie_db_copy)
-        conn = sqlite3.connect(cookie_db_copy)
-        conn.row_factory = sqlite3.Row
-        with conn:
-            c = conn.cursor()
-            c.execute('SELECT baseDomain, name, value, host, path, expiry,\
-                lastAccessed, creationTime, isSecure, isHttpOnly \
-                FROM moz_cookies \
-                WHERE lastAccessed > ? ; ', (int(mod_since * 1000000),))
-            rows = c.fetchall()
-        os.remove(cookie_db_copy)
-        return rows

--- a/automation/DataAggregator/parquet_schema.py
+++ b/automation/DataAggregator/parquet_schema.py
@@ -24,24 +24,6 @@ fields = [
 ]
 PQ_SCHEMAS['flash_cookies'] = pa.schema(fields)
 
-# profile_cookies
-fields = [
-    pa.field('crawl_id', pa.int32(), nullable=False),
-    pa.field('visit_id', pa.int64(), nullable=False),
-    pa.field('instance_id', pa.int32(), nullable=False),
-    pa.field('baseDomain', pa.string()),
-    pa.field('name', pa.string()),
-    pa.field('value', pa.string()),
-    pa.field('host', pa.string()),
-    pa.field('path', pa.string()),
-    pa.field('expiry', pa.int32()),
-    pa.field('lastAccessed', pa.int32()),
-    pa.field('creationTime', pa.int32()),
-    pa.field('isSecure', pa.bool_()),
-    pa.field('isHttpOnly', pa.bool_())
-]
-PQ_SCHEMAS['profile_cookies'] = pa.schema(fields)
-
 # crawl_history
 fields = [
     pa.field('crawl_id', pa.int32(), nullable=False),

--- a/automation/schema.sql
+++ b/automation/schema.sql
@@ -42,26 +42,6 @@ CREATE TABLE IF NOT EXISTS flash_cookies (
     FOREIGN KEY(visit_id) REFERENCES site_visits(id));
 
 /*
-# profile_cookies
- */
-CREATE TABLE IF NOT EXISTS profile_cookies (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    crawl_id INTEGER NOT NULL,
-    visit_id INTEGER NOT NULL,
-    baseDomain TEXT,
-    name TEXT,
-    value TEXT,
-    host TEXT,
-    path TEXT,
-    expiry INTEGER,
-    lastAccessed INTEGER,
-    creationTime INTEGER,
-    isSecure INTEGER,
-    isHttpOnly INTEGER,
-    FOREIGN KEY(crawl_id) REFERENCES crawl(id),
-    FOREIGN KEY(visit_id) REFERENCES site_visits(id));
-
-/*
 # crawl_history
  */
 CREATE TABLE IF NOT EXISTS crawl_history (

--- a/demo.py
+++ b/demo.py
@@ -19,6 +19,8 @@ manager_params, browser_params = TaskManager.load_default_params(NUM_BROWSERS)
 for i in range(NUM_BROWSERS):
     # Record HTTP Requests and Responses
     browser_params[i]['http_instrument'] = True
+    # Record cookie changes
+    browser_params[i]['cookie_instrument'] = True
     # Enable flash for all three browsers
     browser_params[i]['disable_flash'] = False
 if platform != 'darwin':
@@ -37,10 +39,7 @@ for site in sites:
     command_sequence = CommandSequence.CommandSequence(site)
 
     # Start by visiting the page
-    command_sequence.get(sleep=0, timeout=60)
-
-    # dump_profile_cookies/dump_flash_cookies closes the current tab.
-    command_sequence.dump_profile_cookies(120)
+    command_sequence.get(sleep=3, timeout=60)
 
     # index='**' synchronizes visits between the three browsers
     manager.execute_command_sequence(command_sequence, index='**')

--- a/test/test_storage_vectors.py
+++ b/test/test_storage_vectors.py
@@ -94,25 +94,6 @@ class TestStorageVectors(OpenWPMTest):
         assert lso_content_a == expected_lso_content_a
         assert lso_content_b == expected_lso_content_b
 
-    def test_profile_cookies(self):
-        """ Check that some profile cookies are saved """
-        # Run the test crawl
-        manager_params, browser_params = self.get_config()
-        manager = TaskManager.TaskManager(manager_params, browser_params)
-        # TODO update this to local test site
-        url = 'http://www.yahoo.com'
-        cs = CommandSequence.CommandSequence(url)
-        cs.get(sleep=3, timeout=120)
-        cs.dump_profile_cookies()
-        manager.execute_command_sequence(cs)
-        manager.close()
-
-        # Check that some flash cookies are recorded
-        qry_res = db_utils.query_db(manager_params['db'],
-                                    "SELECT COUNT(*) FROM profile_cookies")
-        prof_cookie_count = qry_res[0][0]
-        assert prof_cookie_count > 0
-
     def test_js_profile_cookies(self):
         """ Check that profile cookies set by JS are saved """
         # Run the test crawl


### PR DESCRIPTION
This command is no longer necessary with the new instrumentation. It was
broken by the latest Firefox upgrade, so it no longer makes sense to
keep it around.