### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Docker volume
+docker-volume
+
+# pytest
+.pytest_cache
+
+# firefox directories
+firefox-bin
+*.app
+
+# PyCharm
+.idea
+
+# Local Python virtual environments
+venv
+
+# npm packages
+automation/Extension/firefox/node_modules
+automation/Extension/webext-instrumentation/node_modules
+
+# built extension artifacts
+automation/Extension/firefox/dist
+automation/Extension/firefox/openwpm.xpi
+automation/Extension/firefox/src/content.js
+automation/Extension/firefox/src/feature.js

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ C:\\nppdf32Log\\debuglog.txt
 .idea/*
 *.idea
 */idea
+
+# Local Python virtual environments
 venv/
 
 # Byte-compiled / optimized / DLL files
@@ -79,7 +81,7 @@ docs/_build/
 # npm packages
 node_modules
 
-# built extension
+# built extension artifacts
 automation/Extension/firefox/dist
 automation/Extension/firefox/openwpm.xpi
 automation/Extension/firefox/src/content.js


### PR DESCRIPTION
Somewhat synchronized with gitignore but dedicated to ignoring the largest files and directories that may be lying around in a developer's openwpm folder.

Before (on my machine):
Sending build context to Docker daemon  1.715GB

After:
Sending build context to Docker daemon  71.97MB