### PR TITLE
Mozilla dockerfile dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,17 @@ jobs:
       install:
       script:
         - docker build -f Dockerfile -t openwpm .
+    - language:
+      python:
+      env:
+        - TESTS="Dockerfile-dev"
+      services:
+        - docker
+      before_install:
+      before_script:
+      install:
+      script:
+        - docker build -f Dockerfile-dev -t openwpm-dev .
     - language: node_js
       python:
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,12 @@ COPY --from=extension /usr/src/app/dist/openwpm-*.zip automation/Extension/firef
 
 # Technically, the automation/Extension/firefox directory could be skipped
 # here, but there is no nice way to do that with the Docker COPY command
-COPY . .
+COPY *.py ./
+COPY automation/*.py automation/*.json automation/*.sql automation/
+COPY automation/Commands automation/Commands/
+COPY automation/DataAggregator automation/DataAggregator/
+COPY automation/DeployBrowsers automation/DeployBrowsers/
+COPY automation/utilities automation/utilities/
 
 # Optionally create an OpenWPM user. This is not strictly required since it is
 # possible to run everything as root as well.

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,44 @@
+FROM ubuntu:18.04
+
+WORKDIR /opt/OpenWPM
+# This is just a performance optimization and can be skipped by non-US
+# based users
+RUN sed -i'' 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.list
+
+RUN apt-get clean -y && rm -r /var/lib/apt/lists/* -vf && apt-get clean -y && apt-get update -y && apt-get upgrade -y && apt-get install sudo -y
+
+# Install the Ubuntu packages as well as firefox and the geckodriver first
+COPY ./install-system.sh .
+RUN ./install-system.sh --no-flash
+
+# Instead of running install-pip-and-packages.sh, the packages are installed
+# manually using pip and pip3 so that python2 and python3 are supported in the
+# final image.
+RUN apt-get -y install python-pip python3-pip
+
+# For some reasons, python3-publicsuffix doesn't work with pip3 at the moment,
+# so install it from the ubuntu repository
+RUN apt-get -y install python3-publicsuffix
+
+COPY requirements.txt .
+RUN pip3 install -U -r requirements.txt && pip install -U -r requirements.txt
+
+# Install node, it's required to build the extension in the same image.
+COPY install-node.sh .
+RUN ./install-node.sh
+RUN npm config set unsafe-perm true
+
+# Add and build the extension
+COPY automation/Extension/firefox ./automation/Extension/firefox
+COPY automation/Extension/webext-instrumentation ./automation/Extension/webext-instrumentation
+COPY build-extension.sh .
+RUN ./build-extension.sh
+
+COPY . .
+
+# Optionally create an OpenWPM user. This is not strictly required since it is
+# possible to run everything as root as well.
+RUN adduser --disabled-password --gecos "OpenWPM"  openwpm
+
+# Alternatively, python3 could be used here
+CMD python demo.py

--- a/README.md
+++ b/README.md
@@ -518,6 +518,16 @@ within the root OpenWPM directory:
 
 After a few minutes, the container is ready to use.
 
+Optionally, you may consider using a container to test and develop OpenWPM
+using the _Dockerfile-dev_ dockerfile. The resulting image contains everything
+the standard OpenWPM image contains and also the _.git_ folder, the tests and
+the build environment for the OpenWPM Firefox extension. Use the following
+command to build the development image:
+
+```
+    docker build -f Dockerfile-dev -t openwpm-dev .
+```
+
 ### Running Measurements from inside the Container
 
 You can run the demo measurement from inside the container, as follows:


### PR DESCRIPTION
Add a development Dockerfile

The current Dockerfile is optimized to run OpenWPM, but it is less useful for development. This commit adds a Dockerfile-dev, which contains also the tools that are required to modify and test OpenWPM.

This PR makes the current Dockerfile also a bit lighter by removing everything that is not needed to just _run_ OpenWPM.