### PR TITLE
Print the result of the build extension script when it has finished

### DIFF
--- a/build-extension.sh
+++ b/build-extension.sh
@@ -5,3 +5,5 @@ cd automation/Extension/firefox
 npm install
 npm run build
 cp dist/*.zip ./openwpm.xpi
+
+echo "Success: automation/Extension/firefox/openwpm.xpi has been built"


### PR DESCRIPTION
Before looking into the script, I was unsure that the openwpi.xpi actually got replaced by the freshly built xpi (mentioned last in the current output: `Your web extension is ready: dist/openwpm-1.0.zip`). This clarifies that.