### PR TITLE
Pass config['testing'] testing flag to content scripts

### DIFF
--- a/automation/Extension/firefox/content.js/index.js
+++ b/automation/Extension/firefox/content.js/index.js
@@ -1,4 +1,4 @@
 import { injectJavascriptInstrumentPageScript } from "openwpm-webext-instrumentation";
 
-injectJavascriptInstrumentPageScript(true);
-
+const testing = window.openWpmTesting || false;
+injectJavascriptInstrumentPageScript(testing);

--- a/automation/Extension/firefox/content.js/index.js
+++ b/automation/Extension/firefox/content.js/index.js
@@ -1,4 +1,4 @@
 import { injectJavascriptInstrumentPageScript } from "openwpm-webext-instrumentation";
 
-const testing = window.openWpmTesting || false;
+const testing = openWpmTesting || false;
 injectJavascriptInstrumentPageScript(testing);

--- a/automation/Extension/firefox/feature.js/index.js
+++ b/automation/Extension/firefox/feature.js/index.js
@@ -24,6 +24,7 @@ async function main() {
       http_instrument:true,
       save_javascript:false,
       save_all_content:false,
+      testing:true,
       crawl_id:0
     };
   }
@@ -48,7 +49,7 @@ async function main() {
     loggingDB.logDebug("Javascript instrumentation enabled");
     let jsInstrument = new JavascriptInstrument(loggingDB);
     jsInstrument.run(config['crawl_id']);
-    await jsInstrument.registerContentScript();
+    await jsInstrument.registerContentScript(config['testing']);
   }
 
   if (config['http_instrument']) {

--- a/automation/Extension/webext-instrumentation/src/background/javascript-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/javascript-instrument.ts
@@ -110,7 +110,16 @@ export class JavascriptInstrument {
     });
   }
 
-  public async registerContentScript() {
+  public async registerContentScript(testing = false) {
+    if (testing) {
+      await browser.contentScripts.register({
+        js: [{ code: "window.openWpmTesting = true;" }],
+        matches: ["<all_urls>"],
+        allFrames: true,
+        runAt: "document_start",
+        matchAboutBlank: true,
+      });
+    }
     return browser.contentScripts.register({
       js: [{ file: "/content.js" }],
       matches: ["<all_urls>"],

--- a/automation/Extension/webext-instrumentation/src/background/javascript-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/javascript-instrument.ts
@@ -113,7 +113,7 @@ export class JavascriptInstrument {
   public async registerContentScript(testing = false) {
     if (testing) {
       await browser.contentScripts.register({
-        js: [{ code: "window.openWpmTesting = true;" }],
+        js: [{ code: "const openWpmTesting = true;" }],
         matches: ["<all_urls>"],
         allFrames: true,
         runAt: "document_start",


### PR DESCRIPTION
Fixes #376

Related: https://github.com/mozilla/OpenWPM/pull/291#issue-273586535

Also paves way for https://github.com/mozilla/OpenWPM/issues/353 by providing a method of passing config options without editing the content script.

Note: This PR includes the commit from #375, so to keep clean PRs, that PR should be merged first, followed by this being rebased on the subsequent master.