### PR TITLE
Disable profile saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,11 @@ left out of this section.
 Browser Profile Support
 -----------------------
 
+**WARNING: Stateful crawls are currently not supported. Attempts to run
+stateful crawls will throw `NotImplementedError`s. The work required to
+restore support is tracked in
+[this project](https://github.com/mozilla/OpenWPM/projects/2).**
+
 ### Stateful vs Stateless crawls
 
 By default OpenWPM performs a "stateful" crawl, in that it keeps a consistent

--- a/automation/BrowserManager.py
+++ b/automation/BrowserManager.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import signal
 import sys
-import tempfile
 import time
 import traceback
 
@@ -16,7 +15,7 @@ from six.moves import cPickle as pickle
 from six.moves.queue import Empty as EmptyQueue
 from tblib import pickling_support
 
-from .Commands import command_executor, profile_commands
+from .Commands import command_executor
 from .DeployBrowsers import deploy_browser
 from .Errors import BrowserConfigError, BrowserCrashError, ProfileLoadError
 from .MPLogger import loggingclient
@@ -78,8 +77,8 @@ class Browser:
 
     def ready(self):
         """ return if the browser is ready to accept a command """
-        return (self.command_thread is None or
-                not self.command_thread.is_alive())
+        return self.command_thread is None or \
+            not self.command_thread.is_alive()
 
     def set_visit_id(self, visit_id):
         self.curr_visit_id = visit_id
@@ -89,8 +88,10 @@ class Browser:
         sets up the BrowserManager and gets the process id, browser pid and,
         if applicable, screen pid. loads associated user profile if necessary
         """
+        # Unsupported. See https://github.com/mozilla/OpenWPM/projects/2
         # if this is restarting from a crash, update the tar location
         # to be a tar of the crashed browser's history
+        """
         if self.current_profile_path is not None:
             # tar contents of crashed profile to a temp dir
             tempdir = tempfile.mkdtemp(prefix="owpm_profile_archive_") + "/"
@@ -108,8 +109,9 @@ class Browser:
             self.browser_params['random_attributes'] = False
             crash_recovery = True
         else:
-            tempdir = None
-            crash_recovery = False
+        """
+        tempdir = None
+        crash_recovery = False
         self.is_fresh = not crash_recovery
 
         # Try to spawn the browser within the timelimit
@@ -127,8 +129,8 @@ class Browser:
                 raise BrowserCrashError(
                     'Browser spawn returned failure status')
 
-        while (not success and
-                unsuccessful_spawns < self._UNSUCCESSFUL_SPAWN_LIMIT):
+        while not success and \
+                unsuccessful_spawns < self._UNSUCCESSFUL_SPAWN_LIMIT:
             self.logger.debug("BROWSER %i: Spawn attempt %i " % (
                 self.crawl_id, unsuccessful_spawns))
             # Resets the command/status queues
@@ -229,8 +231,8 @@ class Browser:
                 self.crawl_id, self.browser_manager.pid, self.display_pid,
                 self.display_port, self.browser_pid)
         )
-        if (self.browser_manager is not None and
-                self.browser_manager.pid is not None):
+        if self.browser_manager is not None and \
+                self.browser_manager.pid is not None:
             try:
                 os.kill(self.browser_manager.pid, signal.SIGKILL)
             except OSError:
@@ -305,6 +307,15 @@ class Browser:
         self.kill_browser_manager()
 
         # Archive browser profile (if requested)
+        if not during_init and \
+                self.browser_params['profile_archive_dir'] is not None:
+            self.logger.warn(
+                "BROWSER %i: Archiving the browser profile directory is "
+                "currently unsupported. "
+                "See: https://github.com/mozilla/OpenWPM/projects/2" %
+                self.crawl_id
+            )
+        """
         self.logger.debug(
             "BROWSER %i: during_init=%s | profile_archive_dir=%s" % (
                 self.crawl_id, str(during_init),
@@ -325,6 +336,7 @@ class Browser:
                 compress=True,
                 save_flash=self.browser_params['disable_flash'] is False
             )
+        """
 
         # Clean up temporary files
         if self.current_profile_path is not None:
@@ -351,8 +363,8 @@ def BrowserManager(command_queue, status_queue, browser_params,
 
         # Read the extension port -- if extension is enabled
         # TODO: Initial communication from extension to TM should use sockets
-        if (browser_params['browser'] == 'firefox' and
-                browser_params['extension_enabled']):
+        if browser_params['browser'] == 'firefox' and \
+                browser_params['extension_enabled']:
             logger.debug("BROWSER %i: Looking for extension port information "
                          "in %s" % (browser_params['crawl_id'], prof_folder))
             elapsed = 0

--- a/automation/CommandSequence.py
+++ b/automation/CommandSequence.py
@@ -23,7 +23,7 @@ class CommandSequence:
     called prior to that.
     """
 
-    def __init__(self, url, reset=True, blocking=False):
+    def __init__(self, url, reset=False, blocking=False):
         """Initialize command sequence.
 
         Parameters
@@ -37,11 +37,6 @@ class CommandSequence:
         """
         self.url = url
         self.reset = reset
-        if not self.reset:
-            raise NotImplementedError(
-                "Stateful crawls are not currently supported. "
-                "See https://github.com/mozilla/OpenWPM/projects/2."
-            )
         self.blocking = blocking
         self.commands_with_timeout = []
         self.total_timeout = 0

--- a/automation/CommandSequence.py
+++ b/automation/CommandSequence.py
@@ -37,6 +37,11 @@ class CommandSequence:
         """
         self.url = url
         self.reset = reset
+        if not self.reset:
+            raise NotImplementedError(
+                "Stateful crawls are not currently supported. "
+                "See https://github.com/mozilla/OpenWPM/projects/2."
+            )
         self.blocking = blocking
         self.commands_with_timeout = []
         self.total_timeout = 0

--- a/automation/CommandSequence.py
+++ b/automation/CommandSequence.py
@@ -23,7 +23,7 @@ class CommandSequence:
     called prior to that.
     """
 
-    def __init__(self, url, reset=False, blocking=False):
+    def __init__(self, url, reset=True, blocking=False):
         """Initialize command sequence.
 
         Parameters
@@ -70,6 +70,9 @@ class CommandSequence:
     def dump_profile(self, dump_folder, close_webdriver=False,
                      compress=True, timeout=120):
         """ dumps from the profile path to a given file (absolute path) """
+        raise NotImplementedError(
+            "Profile saving is currently unsupported. "
+            "See: https://github.com/mozilla/OpenWPM/projects/2.")
         self.total_timeout += timeout
         command = ('DUMP_PROF', dump_folder, close_webdriver, compress)
         self.commands_with_timeout.append((command, timeout))

--- a/automation/Commands/browser_commands.py
+++ b/automation/Commands/browser_commands.py
@@ -292,8 +292,8 @@ def screenshot_full_page(visit_id, crawl_id, driver, manager_params,
             driver, 'return window.scrollY;')
         prev_scrollY = -1
         driver.save_screenshot(outname % (part, curr_scrollY))
-        while ((curr_scrollY + inner_height) < max_height and
-                curr_scrollY != prev_scrollY):
+        while (curr_scrollY + inner_height) < max_height and \
+                curr_scrollY != prev_scrollY:
 
             # Scroll down to bottom of previous viewport
             try:

--- a/automation/Commands/profile_commands.py
+++ b/automation/Commands/profile_commands.py
@@ -114,6 +114,11 @@ def dump_profile(browser_profile_folder, manager_params, browser_params,
     # Connect to logger
     logger = loggingclient(*manager_params['logger_address'])
 
+    logger.debug("BROWSER %i: Profile dumping is currently unsupported. "
+                 "See: https://github.com/mozilla/OpenWPM/projects/2." %
+                 browser_params['crawl_id'])
+    return
+
     # ensures that folder paths end with slashes
     if browser_profile_folder[-1] != '/':
         browser_profile_folder = browser_profile_folder + "/"
@@ -165,14 +170,14 @@ def dump_profile(browser_profile_folder, manager_params, browser_params,
     ]
     for item in storage_vector_files:
         full_path = os.path.join(browser_profile_folder, item)
-        if (not os.path.isfile(full_path) and
-                full_path[-3:] != 'shm' and
-                full_path[-3:] != 'wal'):
+        if not os.path.isfile(full_path) and \
+                full_path[-3:] != 'shm' and \
+                full_path[-3:] != 'wal':
             logger.critical(
                 "BROWSER %i: %s NOT FOUND IN profile folder, skipping." %
                 (browser_params['crawl_id'], full_path))
-        elif (not os.path.isfile(full_path) and
-              (full_path[-3:] == 'shm' or full_path[-3:] == 'wal')):
+        elif not os.path.isfile(full_path) and \
+                (full_path[-3:] == 'shm' or full_path[-3:] == 'wal'):
             continue  # These are just checkpoint files
         tar.add(full_path, arcname=item)
     for item in storage_vector_dirs:

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -428,6 +428,17 @@ class TaskManager:
                 condition.wait()
 
         reset = command_sequence.reset
+        if not reset:
+            self.logger.warn(
+                "BROWSER %i: Browser will not reset after CommandSequence "
+                "executes. OpenWPM does not currently support stateful crawls "
+                "(see: https://github.com/mozilla/OpenWPM/projects/2). "
+                "The next command issued to this browser may or may not "
+                "use the same profile (depending on the failure status of "
+                "this command). To prevent this warning, initialize the "
+                "CommandSequence with `reset` set to `True` to use a fresh "
+                "profile for each command." % browser.crawl_id
+            )
         start_time = None
         for command_and_timeout in command_sequence.commands_with_timeout:
             command, timeout = command_and_timeout

--- a/demo.py
+++ b/demo.py
@@ -40,7 +40,7 @@ manager = TaskManager.TaskManager(manager_params, browser_params)
 
 # Visits the sites with all browsers simultaneously
 for site in sites:
-    command_sequence = CommandSequence.CommandSequence(site)
+    command_sequence = CommandSequence.CommandSequence(site, reset=True)
 
     # Start by visiting the page
     command_sequence.get(sleep=3, timeout=60)

--- a/test/test_crawl.py
+++ b/test/test_crawl.py
@@ -51,6 +51,7 @@ class TestCrawl(OpenWPMTest):
         browser_params[0]['http_instrument'] = True
         return manager_params, browser_params
 
+    @pytest.mark.xfail(run=False)
     @pytest.mark.slow
     def test_browser_profile_coverage(self, tmpdir):
         """ Test the coverage of the browser's profile

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -20,6 +20,7 @@ class TestProfile(OpenWPMTest):
             join(manager_params['data_directory'], 'browser_profile')
         return manager_params, browser_params
 
+    @pytest.mark.xfail(run=False)
     def test_saving(self):
         manager_params, browser_params = self.get_config()
         manager = TaskManager.TaskManager(manager_params, browser_params)
@@ -28,6 +29,7 @@ class TestProfile(OpenWPMTest):
         assert isfile(join(browser_params[0]['profile_archive_dir'],
                            'profile.tar.gz'))
 
+    @pytest.mark.xfail(run=False)
     def test_crash(self):
         manager_params, browser_params = self.get_config()
         manager_params['failure_limit'] = 0
@@ -37,6 +39,7 @@ class TestProfile(OpenWPMTest):
             manager.get('example.com')  # Selenium requires scheme prefix
             manager.get('example.com')  # Requires two commands to shut down
 
+    @pytest.mark.xfail(run=False)
     def test_crash_profile(self):
         manager_params, browser_params = self.get_config()
         manager_params['failure_limit'] = 2
@@ -52,6 +55,7 @@ class TestProfile(OpenWPMTest):
         assert isfile(join(browser_params[0]['profile_archive_dir'],
                            'profile.tar.gz'))
 
+    @pytest.mark.xfail(run=False)
     def test_profile_error(self):
         manager_params, browser_params = self.get_config()
         browser_params[0]['profile_tar'] = '/tmp/NOTREAL'


### PR DESCRIPTION
Profile saving has long had intermittent issues. The update to Firefox 68 has fully broken profile saving. I've created [a project](https://github.com/mozilla/OpenWPM/projects/2) to track these issues, have added exceptions to OpenWPM for codepaths that rely on a browser profile (stateful crawling and profile dumping), and have disabled the profile tests.