### PR TITLE
Fix visit_id range for JS limits.

### DIFF
--- a/automation/DataAggregator/BaseAggregator.py
+++ b/automation/DataAggregator/BaseAggregator.py
@@ -93,10 +93,9 @@ class BaseListener(object):
 
     def drain_queue(self):
         """ Ensures queue is empty before closing """
-        self.sock.close()
         time.sleep(3)  # TODO: the socket needs a better way of closing
-        while not self.sock.queue.empty():
-            record = self.sock.queue.get()
+        while not self.record_queue.empty():
+            record = self.record_queue.get()
             self.process_record(record)
 
 

--- a/automation/DataAggregator/S3Aggregator.py
+++ b/automation/DataAggregator/S3Aggregator.py
@@ -257,8 +257,8 @@ class S3Listener(BaseListener):
     def drain_queue(self):
         """Process remaining records in queue and sync final files to S3"""
         super(S3Listener, self).drain_queue()
-        for crawl_id in self.browser_map.keys():
-            self._create_batch(self.browser_map[crawl_id])
+        for visit_id in self.browser_map.values():
+            self._create_batch(visit_id)
         self._send_to_s3(force=True)
 
 

--- a/automation/DataAggregator/S3Aggregator.py
+++ b/automation/DataAggregator/S3Aggregator.py
@@ -257,6 +257,8 @@ class S3Listener(BaseListener):
     def drain_queue(self):
         """Process remaining records in queue and sync final files to S3"""
         super(S3Listener, self).drain_queue()
+        for crawl_id in self.browser_map.keys():
+            self._create_batch(self.browser_map[crawl_id])
         self._send_to_s3(force=True)
 
 
@@ -325,9 +327,14 @@ class S3Aggregator(BaseAggregator):
             raise
 
     def get_next_visit_id(self):
-        """Generate visit id as randomly generated 64bit UUIDs
+        """Generate visit id as randomly generated 53bit UUIDs.
+
+        Parquet can support integers up to 64 bits, but Javascript can only
+        represent integers up to 53 bits:
+        https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+        Thus, we cap these values at 53 bits.
         """
-        return (uuid.uuid4().int & (1 << 64) - 1) - 2**63
+        return (uuid.uuid4().int & (1 << 53) - 1) - 2**52
 
     def get_next_crawl_id(self):
         """Generate crawl id as randomly generated 32bit UUIDs

--- a/test/openwpmtest.py
+++ b/test/openwpmtest.py
@@ -40,7 +40,8 @@ class OpenWPMTest(object):
             load_default_params(num_browsers)
         manager_params['data_directory'] = data_dir
         manager_params['log_directory'] = data_dir
-        browser_params[0]['headless'] = True
+        for i in range(num_browsers):
+            browser_params[i]['headless'] = True
         manager_params['db'] = join(manager_params['data_directory'],
                                     manager_params['database_name'])
         return manager_params, browser_params

--- a/test/test_pages/s3_aggregator.html
+++ b/test/test_pages/s3_aggregator.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+<title>Simple test page</title>
+  <script type="application/javascript">
+    function set_cookie() {
+        document.cookie = 'test_cookie='+Math.random()+'; expires=Tue, 31 Dec 2030 00:00:00 UTC; path=/';
+        console.log(window.navigator.userAgent);
+     }
+  </script>
+ </head>
+ <body onload="set_cookie()">
+   <img src='shared/test_image.png' />
+   <img alt='test image' src='/MAGIC_REDIRECT/req1.png?dst=req2.png&dst=req3.png&dst=/test_pages/shared/test_image_2.png' />
+ </body></html>

--- a/test/test_s3_aggregator.py
+++ b/test/test_s3_aggregator.py
@@ -61,12 +61,8 @@ class TestS3Aggregator(OpenWPMTest):
                 continue
             table = dataset.load_table(table_name)
             visit_ids[table_name] = table.visit_id.unique()
-            table.to_json('/tmp/test-%s.json' % table_name)
-            print(visit_ids[table_name])
-            print("checking table %s" % table_name)
             assert len(visit_ids[table_name]) == NUM_VISITS * NUM_BROWSERS
         for table_name, ids in visit_ids.items():
-            print("checking table %s" % table_name)
             assert set(ids) == set(visit_ids['site_visits'])
 
         assert TEST_SITE in dataset.load_table(

--- a/test/test_s3_aggregator.py
+++ b/test/test_s3_aggregator.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
 
+from collections import defaultdict
+
 import boto3
 from localstack.services import infra
 
 from ..automation import TaskManager
+from ..automation.DataAggregator.parquet_schema import PQ_SCHEMAS
 from .openwpmtest import OpenWPMTest
 from .utilities import (BASE_TEST_URL, LocalS3Dataset, LocalS3Session,
                         local_s3_bucket)
@@ -22,27 +25,49 @@ class TestS3Aggregator(OpenWPMTest):
     def teardown_class(self):
         infra.stop_infra()
 
-    def get_config(self, data_dir=""):
-        manager_params, browser_params = self.get_test_config(data_dir)
+    def get_config(self, num_browsers=1, data_dir=""):
+        manager_params, browser_params = self.get_test_config(
+            data_dir, num_browsers=num_browsers)
         manager_params['output_format'] = 's3'
         manager_params['s3_bucket'] = local_s3_bucket(self.s3_resource)
         manager_params['s3_directory'] = 's3-aggregator-tests'
-        browser_params[0]['http_instrument'] = True
+        for i in range(num_browsers):
+            browser_params[i]['http_instrument'] = True
+            browser_params[i]['js_instrument'] = True
+            browser_params[i]['cookie_instrument'] = True
+            browser_params[i]['navigation_instrument'] = True
         return manager_params, browser_params
 
-    def test_s3_aggregation(self, tmpdir):
-        TEST_SITE = "%s/http_test_page.html" % BASE_TEST_URL
-
-        # Run the test crawl
-        manager_params, browser_params = self.get_config()
+    def test_visit_id_consistency(self):
+        TEST_SITE = "%s/s3_aggregator.html" % BASE_TEST_URL
+        NUM_VISITS = 2
+        NUM_BROWSERS = 4
+        manager_params, browser_params = self.get_config(
+            num_browsers=NUM_BROWSERS)
         manager = TaskManager.TaskManager(manager_params, browser_params)
-        manager.get(TEST_SITE)
+        for i in range(NUM_VISITS):
+            manager.get(TEST_SITE, sleep=1, index='*')
         manager.close()
 
         dataset = LocalS3Dataset(
             manager_params['s3_bucket'],
             manager_params['s3_directory']
         )
-        requests = dataset.load_table('http_requests')
 
-        assert TEST_SITE in requests.top_level_url.unique()
+        visit_ids = defaultdict(set)
+        for table_name in PQ_SCHEMAS:
+            # flash cookie instrumentation not enabled
+            if table_name == 'flash_cookies':
+                continue
+            table = dataset.load_table(table_name)
+            visit_ids[table_name] = table.visit_id.unique()
+            table.to_json('/tmp/test-%s.json' % table_name)
+            print(visit_ids[table_name])
+            print("checking table %s" % table_name)
+            assert len(visit_ids[table_name]) == NUM_VISITS * NUM_BROWSERS
+        for table_name, ids in visit_ids.items():
+            print("checking table %s" % table_name)
+            assert set(ids) == set(visit_ids['site_visits'])
+
+        assert TEST_SITE in dataset.load_table(
+            'http_requests').top_level_url.unique()


### PR DESCRIPTION
Will fix #277. Alternative to https://github.com/mozilla/OpenWPM/pull/323, which has errors related to signed/unsigned integers and does not pass the new included test. I verified that the master branch fails this test due to the truncation issue.

This also fixes two other issues:
* The S3 Aggregator would silently drop the last page visit (or set of visits).
* `utilities::get_test_config` accepts a browser count as an argument, but only makes the first browser headless.