### PR TITLE
Disable virtual display creation for MacOS

### DIFF
--- a/automation/DeployBrowsers/deploy_firefox.py
+++ b/automation/DeployBrowsers/deploy_firefox.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import json
 import os.path
 import random
+import sys
 
 from pyvirtualdisplay import Display
 from selenium import webdriver
@@ -94,10 +95,16 @@ def deploy_firefox(status_queue, browser_params, manager_params,
                           profile_settings['ua_string'])
 
     if browser_params['headless']:
-        display = Display(visible=0, size=profile_settings['screen_res'])
-        display.start()
-        display_pid = display.pid
-        display_port = display.cmd_param[-1][1:]
+        if sys.platform == 'darwin':
+            logger.warn(
+                "BROWSER %i: headless mode is not supported on MacOS. "
+                "Browser window will be visible." % browser_params['crawl_id']
+            )
+        else:
+            display = Display(visible=0, size=profile_settings['screen_res'])
+            display.start()
+            display_pid = display.pid
+            display_port = display.cmd_param[-1][1:]
     status_queue.put(('STATUS', 'Display', (display_pid, display_port)))
 
     if browser_params['extension_enabled']:

--- a/demo.py
+++ b/demo.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from sys import platform
-
 from six.moves import range
 
 from automation import CommandSequence, TaskManager
@@ -27,8 +25,7 @@ for i in range(NUM_BROWSERS):
     browser_params[i]['js_instrument'] = True
     # Enable flash for all three browsers
     browser_params[i]['disable_flash'] = False
-if platform != 'darwin':
-    browser_params[0]['headless'] = True  # Launch only browser 0 headless
+browser_params[0]['headless'] = True  # Launch only browser 0 headless
 
 # Update TaskManager configuration (use this for crawl-wide settings)
 manager_params['data_directory'] = '~/Desktop/'


### PR DESCRIPTION
We know MacOS will throw XVFB errors when we attempt to start a virtual display using `pyvirtualdisplay`. Rather than relying on a user to skip the `headless` configuration, we prevent OpenWPM from initializing the display on darwin even when the config parameter is set.

@nhnt11 or @motin: do you mind to test this on MacOS?