### PR TITLE
[WIP] Convert S3Aggregator to ParquetAggregator

### DIFF
--- a/automation/DataAggregator/ParquetAggregator.py
+++ b/automation/DataAggregator/ParquetAggregator.py
@@ -341,7 +341,7 @@ class ParquetAggregator(BaseAggregator):
         else:
             raise ValueError(
                 "The ParquetAggregator supports saving data to the local disk "
-                "(`local`) or to Amazon S3 (`s3`). You set "
+                "(`local_parquet`) or to Amazon S3 (`s3`). You set "
                 "manager_params['output_format'] to %s." %
                 manager_params['output_format']
             )

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -16,7 +16,7 @@ from tblib import pickling_support
 
 from . import CommandSequence, MPLogger
 from .BrowserManager import Browser
-from .DataAggregator import LocalAggregator, S3Aggregator
+from .DataAggregator import LocalAggregator, ParquetAggregator
 from .Errors import CommandExecutionError
 from .SocketInterface import clientsocket
 from .utilities.platform_utils import get_configuration_string, get_version
@@ -220,8 +220,9 @@ class TaskManager:
         if self.manager_params["output_format"] == "local":
             self.data_aggregator = LocalAggregator.LocalAggregator(
                 self.manager_params, self.browser_params)
-        elif self.manager_params["output_format"] == "s3":
-            self.data_aggregator = S3Aggregator.S3Aggregator(
+        elif (self.manager_params["output_format"] == "s3" or
+              self.manager_params["output_format"] == "local_parquet"):
+            self.data_aggregator = ParquetAggregator.ParquetAggregator(
                 self.manager_params, self.browser_params)
         else:
             raise Exception("Unrecognized output format: %s" %

--- a/automation/default_manager_params.json
+++ b/automation/default_manager_params.json
@@ -5,5 +5,6 @@
     "database_name": "crawl-data.sqlite",
     "log_file": "openwpm.log",
     "failure_limit": null,
-    "testing": false
+    "testing": false,
+    "parquet_batch_size": 500
 }

--- a/test/test_parquet_aggregator.py
+++ b/test/test_parquet_aggregator.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import, print_function
+
+from Queue import Queue
+
+from ..automation.DataAggregator import ParquetAggregator
+from .openwpmtest import OpenWPMTest
+
+
+class TestParquetAggregator(OpenWPMTest):
+    """Test ParquetListener and ParquetAggregator"""
+
+    def get_test_config(self):
+        manager_params, browser_params = super(
+            TestParquetAggregator, self).get_test_config()
+        manager_params['output_format'] = 'local_parquet'
+        manager_params['parquet_batch_size'] = 10
+        return manager_params, browser_params
+
+    def get_listener(self):
+        manager_params, browser_params = self.get_test_config()
+        self.status_queue = Queue()
+        self.shutdown_queue = Queue()
+        return ParquetAggregator.ParquetListener(
+            self.status_queue, self.shutdown_queue, manager_params, 0)
+
+    def test_listener(self):
+        # listener = self.get_listener()
+        assert True


### PR DESCRIPTION
See #294 for motivation. I've stopped working on this because I think it's going to be more complex than I expected. While it's true that we can easily save the parquet database locally, we need to handle the de-duplicated content somehow. We currently write content to a `content` directory on S3 rather than as a table in the database. This lets us de-duplicate across independent crawls (but leads to #247). So how do we save these when saving locally? Also as individual files? But we know that's super inefficient. The current `LocalAggregator` uses a LevelDB database to store the files. This is very performant, but I didn't want to duplicate that logic in the ParquetAggregator class. So we'll need to do some refactoring or rethink how we save content files.