### PR TITLE
Set @openwpm/webext-instrumentation package to be published as a public package

### DIFF
--- a/automation/Extension/webext-instrumentation/.publishrc
+++ b/automation/Extension/webext-instrumentation/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": "@openwpm/webext-instrumentation@"
   },
   "confirm": true,
-  "publishCommand": "npm publish",
+  "publishCommand": "npm publish --access=public",
   "publishTag": "latest",
   "prePublishScript": "npm test",
   "postPublishScript": false


### PR DESCRIPTION
Required since scoped npm packages are attempted to be published as private by default.

Blocks https://github.com/mozilla/OpenWPM/issues/329