### PR TITLE
Use the Unbranded build that corresponds to Firefox 68 release (for both Linux and Mac)

### DIFF
--- a/install-mac-dev.sh
+++ b/install-mac-dev.sh
@@ -28,9 +28,9 @@ CFLAGS='-mmacosx-version-min=10.7 -stdlib=libc++ -std=c++11' pip install --force
 # Make npm available (used by build-extension.sh)
 brew install node || true
 
-# Download the latest Unbranded Firefox Release version
-brew install wget || brew upgrade wget
-wget https://index.taskcluster.net/v1/task/gecko.v2.mozilla-release.latest.firefox.macosx64-add-on-devel/artifacts/public/build/target.dmg
+# Use the Unbranded build that corresponds to Firefox 68 release (source: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
+brew install wget || true
+wget https://queue.taskcluster.net/v1/task/EPaShNEQTYaBrJYpULyxwg/runs/0/artifacts/public/build/target.dmg
 
 # Install Firefox Nightly
 rm -rf Nightly.app || true

--- a/install-system.sh
+++ b/install-system.sh
@@ -48,9 +48,8 @@ if [ "$flash" = true ]; then
     sudo apt-get install -y adobe-flashplugin
 fi
 
-# We use the latest unbranded release build. For the time being, we hardcode
-# a specific build from Taskcluster.
-wget https://index.taskcluster.net/v1/task/gecko.v2.mozilla-release.pushdate.2019.07.01.20190701165736.firefox.linux64-add-on-devel/artifacts/public/build/target.tar.bz2
+# Use the Unbranded build that corresponds to Firefox 68 release (source: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
+wget https://queue.taskcluster.net/v1/task/HYGMEM_UT06yMsOpWtHyVQ/runs/0/artifacts/public/build/target.tar.bz2
 tar jxf target.tar.bz2
 rm -rf firefox-bin
 mv firefox firefox-bin


### PR DESCRIPTION
In https://github.com/mozilla/OpenWPM/pull/385 we hard-coded the unbranded version of Firefox to a specific build. 

This PR makes this available also for the Mac build, and changes the build to correspond to the one that matches Firefox 68 (according to https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds where this is tracked)