### PR TITLE
Move config files into subdirectory

### DIFF
--- a/automation/DataAggregator/S3Aggregator.py
+++ b/automation/DataAggregator/S3Aggregator.py
@@ -23,6 +23,7 @@ from .parquet_schema import PQ_SCHEMAS
 CACHE_SIZE = 500
 SITE_VISITS_INDEX = '_site_visits_index'
 CONTENT_DIRECTORY = 'content'
+CONFIG_DIR = 'config'
 
 
 def listener_process_runner(
@@ -321,8 +322,8 @@ class S3Aggregator(BaseAggregator):
         """Save configuration details for this crawl to the database"""
 
         # Save config keyed by task id
-        fname = "%s/instance-%s_configuration.json" % (
-            self.dir, self._instance_id)
+        fname = "%s/%s/instance-%s_configuration.json" % (
+            self.dir, CONFIG_DIR, self._instance_id)
 
         # Config parameters for update
         out = dict()

--- a/crawler.py
+++ b/crawler.py
@@ -64,7 +64,7 @@ while not job_queue.empty():
     job = job_queue.lease(lease_secs=120, block=True, timeout=5)
     if job is None:
         manager.logger.info("Waiting for work")
-        time.sleep(1)
+        time.sleep(5)
     else:
         site_rank, site = job.decode("utf-8").split(',')
         if "://" not in site:

--- a/test/test_s3_aggregator.py
+++ b/test/test_s3_aggregator.py
@@ -83,7 +83,8 @@ class TestS3Aggregator(OpenWPMTest):
         # of configuration files
         config_file = dataset.list_files('config', prepend_root=True)
         assert len(config_file) == 1  # only one instance started in test
-        config = json.loads(six.text_type(dataset.get_file(config_file[0])))
+        config = json.loads(six.text_type(
+            dataset.get_file(config_file[0], 'utf-8')))
         assert len(config['browser_params']) == NUM_BROWSERS
 
     def test_commit_on_timeout(self):

--- a/test/test_s3_aggregator.py
+++ b/test/test_s3_aggregator.py
@@ -84,7 +84,7 @@ class TestS3Aggregator(OpenWPMTest):
         config_file = dataset.list_files('config', prepend_root=True)
         assert len(config_file) == 1  # only one instance started in test
         config = json.loads(six.text_type(
-            dataset.get_file(config_file[0], 'utf-8')))
+            dataset.get_file(config_file[0]), 'utf-8'))
         assert len(config['browser_params']) == NUM_BROWSERS
 
     def test_commit_on_timeout(self):

--- a/test/test_s3_aggregator.py
+++ b/test/test_s3_aggregator.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import json
 from collections import defaultdict
 
 import boto3
@@ -38,7 +39,7 @@ class TestS3Aggregator(OpenWPMTest):
             browser_params[i]['navigation_instrument'] = True
         return manager_params, browser_params
 
-    def test_visit_id_consistency(self):
+    def test_basic_properties(self):
         TEST_SITE = "%s/s3_aggregator.html" % BASE_TEST_URL
         NUM_VISITS = 2
         NUM_BROWSERS = 4
@@ -54,6 +55,7 @@ class TestS3Aggregator(OpenWPMTest):
             manager_params['s3_directory']
         )
 
+        # Test visit_id consistency
         visit_ids = defaultdict(set)
         for table_name in PQ_SCHEMAS:
             # flash cookie instrumentation not enabled
@@ -65,5 +67,13 @@ class TestS3Aggregator(OpenWPMTest):
         for table_name, ids in visit_ids.items():
             assert set(ids) == set(visit_ids['site_visits'])
 
+        # Ensure http table is created
         assert TEST_SITE in dataset.load_table(
             'http_requests').top_level_url.unique()
+
+        # Ensure config directory is created and contains the correct number
+        # of configuration files
+        config_file = dataset.list_files('config', prepend_root=True)
+        assert len(config_file) == 1  # only one instance started in test
+        config = json.loads(dataset.get_file(config_file[0]))
+        assert len(config['browser_params']) == NUM_BROWSERS

--- a/test/test_s3_aggregator.py
+++ b/test/test_s3_aggregator.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 import boto3
 import pytest
+import six
 from localstack.services import infra
 
 from ..automation import TaskManager
@@ -82,7 +83,7 @@ class TestS3Aggregator(OpenWPMTest):
         # of configuration files
         config_file = dataset.list_files('config', prepend_root=True)
         assert len(config_file) == 1  # only one instance started in test
-        config = json.loads(dataset.get_file(config_file[0]))
+        config = json.loads(six.text_type(dataset.get_file(config_file[0])))
         assert len(config['browser_params']) == NUM_BROWSERS
 
     def test_commit_on_timeout(self):


### PR DESCRIPTION
This moves the config files on S3 into a subdirectory. Since there are typically hundreds of files, this will keep the root directory much cleaner.