### PR TITLE
Pin localstack to older version to fix dependency issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,10 @@ before_install:
   - "export BOTO_CONFIG=/dev/null" # https://github.com/travis-ci/travis-ci/issues/7940
 install:
   - echo "y" | ./install.sh
-  - pip install -r requirements.txt
+  - pip install -r requirements.txt -r requirements-dev.txt
 before_script:
   - flake8
 script:
-  - pip install -r requirements-dev.txt
   - cd test
   - py.test -s -v --durations=10 $TESTS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - "export BOTO_CONFIG=/dev/null" # https://github.com/travis-ci/travis-ci/issues/7940
 install:
   - echo "y" | ./install.sh
-  - pip install -r requirements.txt -r requirements-dev.txt
+  - pip install --upgrade -r requirements.txt -r requirements-dev.txt
 before_script:
   - flake8
 script:

--- a/automation/Commands/utils/XPathUtil.py
+++ b/automation/Commands/utils/XPathUtil.py
@@ -79,7 +79,7 @@ def ExtractXPath(element, use_id=True):
     # Starting node
     # Check id first
     if use_id and element.get('id') is not None:
-        return '//*/' + element.name + '[@id=\"' + element.get('id') + '\"]'
+        return '//*/' + element.name + '[@id="' + element.get('id') + '"]'
 
     xpath = check_previous_tags(element)
 
@@ -91,7 +91,7 @@ def ExtractXPath(element, use_id=True):
 
         # Check id first
         if use_id and parent.get('id') is not None:
-            return '//*/' + parent.name + '[@id=\"' + parent.get('id') + '\"]/' + xpath  # noqa
+            return '//*/' + parent.name + '[@id="' + parent.get('id') + '"]/' + xpath  # noqa
 
         xpath = check_previous_tags(parent) + '/' + xpath
 
@@ -130,11 +130,11 @@ def xp1_wildcard(attr, string, normalize=True):
         pt2 = ''
 
         if parts[0] != '':
-            pt1 = 'starts-with(' + attr + ', \'' + parts[0] + '\')'
+            pt1 = 'starts-with(' + attr + ", '" + parts[0] + "')"
         if parts[1] != '':
-            pt2 = ('contains(substring(' + attr +
-                   ', string-length(' + attr + ')-' + str(len(parts[1]) - 1) +
-                   '), \'' + parts[1] + '\')')
+            pt2 = 'contains(substring(' + attr + \
+                  ', string-length(' + attr + ')-' + \
+                  str(len(parts[1]) - 1) + "), '" + parts[1] + "')"
 
         if pt1 == '' and pt2 != '':
             return '[' + pt2 + ']'

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -203,11 +203,11 @@ class TaskManager:
                     if browser.display_pid is not None:
                         display_pids.add(browser.display_pid)
                 for process in psutil.process_iter():
-                    if (process.create_time() + 300 < check_time and (
-                            (process.name() == 'firefox' and
-                             process.pid not in browser_pids) or
-                            (process.name() == 'Xvfb' and
-                             process.pid not in display_pids))):
+                    if process.create_time() + 300 < check_time and (
+                            (process.name() == 'firefox' and (
+                                process.pid not in browser_pids)) or (
+                            process.name() == 'Xvfb' and (
+                                process.pid not in display_pids))):
                         self.logger.debug("Process: %s (pid: %i) with start "
                                           "time %s found running but not in "
                                           "browser process list. Killing." % (

--- a/automation/utilities/platform_utils.py
+++ b/automation/utilities/platform_utils.py
@@ -48,11 +48,10 @@ def get_firefox_binary_path():
     root_dir = os.path.dirname(__file__) + "/../.."
     if platform == 'darwin':
         firefox_binary_path = os.path.abspath(
-            root_dir +
-            "/Nightly.app/Contents/MacOS/firefox-bin")
+            root_dir + "/Nightly.app/Contents/MacOS/firefox-bin")
     else:
-        firefox_binary_path = os.path.abspath(root_dir +
-                                              "/firefox-bin/firefox-bin")
+        firefox_binary_path = os.path.abspath(
+            root_dir + "/firefox-bin/firefox-bin")
 
     if not os.path.isfile(firefox_binary_path):
         raise RuntimeError(
@@ -69,8 +68,8 @@ def get_geckodriver_exec_path():
     we throw a RuntimeError.
     """
     firefox_binary_path = get_firefox_binary_path()
-    geckodriver_executable_path = (os.path.dirname(firefox_binary_path)
-                                   + "/geckodriver")
+    geckodriver_executable_path = (
+        os.path.dirname(firefox_binary_path) + "/geckodriver")
 
     if not os.path.isfile(geckodriver_executable_path):
         raise RuntimeError(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 autopep8
 localstack
+requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 autopep8
-localstack
-requests
+localstack==0.9.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ skip = venv,automation/Extension,firefox-bin
 
 [flake8]
 exclude = venv,automation/Extension,firefox-bin
+ignore = Q000

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,4 @@ skip = venv,automation/Extension,firefox-bin
 
 [flake8]
 exclude = venv,automation/Extension,firefox-bin
-ignore = Q000
+ignore = Q

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -241,8 +241,8 @@ class TestExtension(OpenWPMTest):
         rows = db_utils.get_javascript_entries(db)
         observed_rows = set()
         for row in rows:
-            if (row['symbol'] == "RTCPeerConnection.setLocalDescription" and
-                    row['operation'] == 'call'):
+            if (row['symbol'] == "RTCPeerConnection.setLocalDescription" and (
+                    row['operation'] == 'call')):
                 sdp_offer = row['arguments']
                 self.check_webrtc_sdp_offer(sdp_offer)
             else:


### PR DESCRIPTION
Broken out from #438.

Localstack released 10.X on August 3rd. The newest version has installation issues. See #439. Pinning to `0.9.6` then introduced a bunch of `flake8` errors that we didn't have before. This is caused by the fact that localstack includes `flake8-quotes` as a dependency (https://travis-ci.org/mozilla/OpenWPM/jobs/568044495#L2129-L2130) and this plugin flags any use of double quotes as an error. Unfortunately flake8 automatically loads any installed plugins and doesn't provide a way to disable an installed plugin or restrict the set of possible plugins (https://gitlab.com/pycqa/flake8/issues/133). Thus, I've decided to disable the entire `QXXX` error code range, which as of 2 years ago isn't used by any plugins we plan to install (https://gitlab.com/pycqa/flake8/issues/339).