### PR TITLE
Extension debug console output sent without stringification

### DIFF
--- a/automation/Extension/firefox/feature.js/loggingdb.js
+++ b/automation/Extension/firefox/feature.js/loggingdb.js
@@ -150,7 +150,7 @@ export let saveRecord = function(instrument, record) {
 
     // send to console if debugging
     if (debugging) {
-      console.log("EXTENSION", instrument, JSON.stringify(record));
+      console.log("EXTENSION", instrument, record);
       return;
     }
     dataAggregator.send(JSON.stringify([instrument, record]));


### PR DESCRIPTION
Allows for easier-on-the-eye inspection from the devtools console.