### PR TITLE
Avoid using "index='**'" in demo.py since it is a bit confusing

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -43,8 +43,8 @@ for site in sites:
     # Start by visiting the page
     command_sequence.get(sleep=3, timeout=60)
 
-    # index='**' synchronizes visits between the three browsers
-    manager.execute_command_sequence(command_sequence, index='**')
+    # Run commands across the three browsers (simple parallelization)
+    manager.execute_command_sequence(command_sequence)
 
 # Shuts down the browsers and waits for the data to finish logging
 manager.close()


### PR DESCRIPTION
I believe this makes the behavior of demo.py somewhat easier to understand, and reflects the most common use case for multiple browsers (simple parallelization).

Ideally, we should have an examples-directory to demonstrate more advanced use cases, so that the demo.py can stay simple.