### PR TITLE
Allow content saving to be configured by any resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ available [below](#output-format).
 * Response body content
     * Saves all files encountered during the crawl to a `LevelDB`
         database de-duplicated by the md5 hash of the content.
-    * Set `browser_params['save_all_content'] = True`
+    * Set `browser_params['save_content'] = True`
     * The `content_hash` column of the `http_responses` table contains the md5
         hash for each script, and can be used to do content lookups in the
         LevelDB content database.
     * NOTE: this instrumentation may lead to performance issues when a large
         number of browsers are in use.
-    * Set `browser_params['save_javascript'] = True` to save only Javascript
+    * Set `browser_params['save_content']` to a comma-separated list of 
+        [resource_types](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType)
+        to save only specific types of files, for instance 
+        `browser_params['save_content'] = "script"` to save only Javascript
         files. This will lessen the performance impact of this instrumentation
         when a large number of browsers are used in parallel.
 * Flash Cookies
@@ -190,10 +193,9 @@ inline by sending a `create_table` message to the data aggregator.
 #### Parquet on Amazon S3 **Experimental**
 As an option, OpenWPM can save data directly to an Amazon S3 bucket as a
 Parquet Dataset. This is currently experimental and hasn't been thoroughly
-tested. Response body content (both `save_javascript` and `save_all_content`),
-screenshots, and page source saving is not currently supported and will still
-be stored in local databases and directories. To enable S3 saving specify the
-following configuration parameters in `manager_params`:
+tested. Screenshots, and page source saving is not currently supported and 
+will still be stored in local databases and directories. To enable S3 
+saving specify the following configuration parameters in `manager_params`:
 * Output format: `manager_params['output_format'] = 's3'`
 * S3 bucket name: `manager_params['s3_bucket'] = 'openwpm-test-crawl'`
 * Directory within S3 bucket: `manager_params['s3_directory'] = '2018-09-09_test-crawl-new'`

--- a/automation/DataAggregator/LocalAggregator.py
+++ b/automation/DataAggregator/LocalAggregator.py
@@ -196,7 +196,7 @@ class LocalAggregator(BaseAggregator):
         # (if content saving is enabled on any browser)
         self.ldb_enabled = False
         for params in browser_params:
-            if params['save_javascript'] or params['save_all_content']:
+            if params['save_content']:
                 self.ldb_enabled = True
                 break
 

--- a/automation/Extension/firefox/feature.js/index.js
+++ b/automation/Extension/firefox/feature.js/index.js
@@ -22,8 +22,7 @@ async function main() {
       cookie_instrument:true,
       js_instrument:true,
       http_instrument:true,
-      save_javascript:false,
-      save_all_content:false,
+      save_content:false,
       testing:true,
       crawl_id:0
     };
@@ -56,8 +55,7 @@ async function main() {
     loggingDB.logDebug("HTTP Instrumentation enabled");
     let httpInstrument = new HttpInstrument(loggingDB);
     httpInstrument.run(config['crawl_id'],
-                       config['save_javascript'],
-                       config['save_all_content']);
+                       config['save_content']);
   }
 }
 

--- a/automation/Extension/firefox/feature.js/index.js
+++ b/automation/Extension/firefox/feature.js/index.js
@@ -15,8 +15,6 @@ async function main() {
     config = JSON.parse(config);
     console.log("Browser Config:", config);
   } else {
-    console.log("WARNING: config not found. Assuming this is a test run of",
-                "the extension. Outputting all queries to console.");
     config = {
       navigation_instrument:true,
       cookie_instrument:true,
@@ -26,6 +24,8 @@ async function main() {
       testing:true,
       crawl_id:0
     };
+    console.log("WARNING: config not found. Assuming this is a test run of",
+                "the extension. Outputting all queries to console.", {config});
   }
 
   await loggingDB.open(config['aggregator_address'],

--- a/automation/Extension/webext-instrumentation/package-lock.json
+++ b/automation/Extension/webext-instrumentation/package-lock.json
@@ -7236,19 +7236,19 @@
       "dev": true,
       "requires": {
         "chalk": "2.4.2",
-        "conventional-changelog": "3.1.10",
+        "conventional-changelog": "3.1.8",
         "conventional-changelog-config-spec": "2.0.0",
-        "conventional-recommended-bump": "6.0.0",
+        "conventional-recommended-bump": "5.0.0",
         "detect-indent": "6.0.0",
         "detect-newline": "3.0.0",
         "dotgitignore": "2.1.0",
         "figures": "3.0.0",
         "find-up": "4.1.0",
         "fs-access": "1.0.1",
-        "git-semver-tags": "3.0.0",
-        "semver": "6.3.0",
+        "git-semver-tags": "2.0.2",
+        "semver": "6.0.0",
         "stringify-package": "1.0.0",
-        "yargs": "13.3.0"
+        "yargs": "13.2.4"
       },
       "dependencies": {
         "ansi-regex": {

--- a/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
@@ -15,7 +15,7 @@ import {
   WebRequestOnCompletedEventDetails,
 } from "../types/browser-web-request-event-details";
 
-type SaveContentOption = boolean | string | ResourceType[];
+type SaveContentOption = boolean | string;
 
 /**
  * Note: Different parts of the desired information arrives in different events as per below:
@@ -185,18 +185,13 @@ export class HttpInstrument {
     if (saveContentOption === false) {
       return false;
     }
-    if (this.saveContentResourceTypes(saveContentOption).length > 0) {
-      return true;
-    }
-    return false;
+    return this.saveContentResourceTypes(saveContentOption).length > 0;
   }
 
   private saveContentResourceTypes(
-    saveContentOption: string | ResourceType[],
+    saveContentOption: string,
   ): ResourceType[] {
-    return typeof saveContentOption === "string"
-      ? (saveContentOption.split(",") as ResourceType[])
-      : saveContentOption;
+    return saveContentOption.split(",") as ResourceType[];
   }
 
   /**

--- a/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
@@ -188,9 +188,7 @@ export class HttpInstrument {
     return this.saveContentResourceTypes(saveContentOption).length > 0;
   }
 
-  private saveContentResourceTypes(
-    saveContentOption: string,
-  ): ResourceType[] {
+  private saveContentResourceTypes(saveContentOption: string): ResourceType[] {
     return saveContentOption.split(",") as ResourceType[];
   }
 

--- a/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
@@ -99,7 +99,7 @@ export class HttpInstrument {
     browser.webRequest.onBeforeRequest.addListener(
       this.onBeforeRequestListener,
       filter,
-      this.shouldPossiblýSaveContent(saveContentOption)
+      this.isContentSavingEnabled(saveContentOption)
         ? ["requestBody", "blocking"]
         : ["requestBody"],
     );
@@ -178,7 +178,7 @@ export class HttpInstrument {
     }
   }
 
-  private shouldPossiblýSaveContent(saveContentOption: SaveContentOption) {
+  private isContentSavingEnabled(saveContentOption: SaveContentOption) {
     if (saveContentOption === true) {
       return true;
     }

--- a/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
@@ -15,6 +15,8 @@ import {
   WebRequestOnCompletedEventDetails,
 } from "../types/browser-web-request-event-details";
 
+type SaveContentOption = boolean | string | ResourceType[];
+
 /**
  * Note: Different parts of the desired information arrives in different events as per below:
  * request = headers in onBeforeSendHeaders + body in onBeforeRequest
@@ -40,7 +42,7 @@ export class HttpInstrument {
     this.dataReceiver = dataReceiver;
   }
 
-  public run(crawlID, saveJavascript, saveAllContent) {
+  public run(crawlID, saveContentOption: SaveContentOption) {
     const allTypes: ResourceType[] = [
       "beacon",
       "csp_report",
@@ -77,7 +79,9 @@ export class HttpInstrument {
      * Attach handlers to event listeners
      */
 
-    this.onBeforeRequestListener = details => {
+    this.onBeforeRequestListener = (
+      details: WebRequestOnBeforeRequestEventDetails,
+    ) => {
       const blockingResponseThatDoesNothing: BlockingResponse = {};
       // Ignore requests made by extensions
       if (requestStemsFromExtension(details)) {
@@ -87,9 +91,7 @@ export class HttpInstrument {
       pendingRequest.resolveOnBeforeRequestEventDetails(details);
       const pendingResponse = this.getPendingResponse(details.requestId);
       pendingResponse.resolveOnBeforeRequestEventDetails(details);
-      if (saveAllContent) {
-        pendingResponse.addResponseResponseBodyListener(details);
-      } else if (saveJavascript && this.isJS(details.type)) {
+      if (this.shouldSaveContent(saveContentOption, details.type)) {
         pendingResponse.addResponseResponseBodyListener(details);
       }
       return blockingResponseThatDoesNothing;
@@ -97,7 +99,7 @@ export class HttpInstrument {
     browser.webRequest.onBeforeRequest.addListener(
       this.onBeforeRequestListener,
       filter,
-      saveJavascript || saveAllContent
+      this.shouldPossiblýSaveContent(saveContentOption)
         ? ["requestBody", "blocking"]
         : ["requestBody"],
     );
@@ -145,8 +147,7 @@ export class HttpInstrument {
         details,
         crawlID,
         incrementedEventOrdinal(),
-        saveJavascript,
-        saveAllContent,
+        saveContentOption,
       );
     };
     browser.webRequest.onCompleted.addListener(
@@ -175,6 +176,49 @@ export class HttpInstrument {
     if (this.onCompletedListener) {
       browser.webRequest.onCompleted.removeListener(this.onCompletedListener);
     }
+  }
+
+  private shouldPossiblýSaveContent(saveContentOption: SaveContentOption) {
+    if (saveContentOption === true) {
+      return true;
+    }
+    if (saveContentOption === false) {
+      return false;
+    }
+    if (this.saveContentResourceTypes(saveContentOption).length > 0) {
+      return true;
+    }
+    return false;
+  }
+
+  private saveContentResourceTypes(
+    saveContentOption: string | ResourceType[],
+  ): ResourceType[] {
+    return typeof saveContentOption === "string"
+      ? (saveContentOption.split(",") as ResourceType[])
+      : saveContentOption;
+  }
+
+  /**
+   * We rely on the resource type to filter responses
+   * See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
+   *
+   * @param saveContentOption
+   * @param resourceType
+   */
+  private shouldSaveContent(
+    saveContentOption: SaveContentOption,
+    resourceType: ResourceType,
+  ) {
+    if (saveContentOption === true) {
+      return true;
+    }
+    if (saveContentOption === false) {
+      return false;
+    }
+    return this.saveContentResourceTypes(saveContentOption).includes(
+      resourceType,
+    );
   }
 
   private getPendingRequest(requestId): PendingRequest {
@@ -582,34 +626,19 @@ export class HttpInstrument {
     }
   }
 
-  /**
-   * Return true if this request is loading javascript
-   * We rely mostly on the content policy type to filter responses
-   * and fall back to the URI and content type string for types that can
-   * load various resource types.
-   * See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
-   *
-   * @param resourceType
-   */
-  private isJS(resourceType: ResourceType): boolean {
-    return resourceType === "script";
-  }
-
   // Instrument HTTP responses
   private async onCompletedHandler(
     details: WebRequestOnCompletedEventDetails,
     crawlID,
     eventOrdinal,
-    saveJavascript,
-    saveAllContent,
+    saveContent,
   ) {
     /*
     console.log(
       "onCompletedHandler (previously httpRequestHandler)",
       details,
       crawlID,
-      saveJavascript,
-      saveAllContent,
+      saveContent,
     );
     */
 
@@ -676,9 +705,7 @@ export class HttpInstrument {
     update.headers = JSON.stringify(headers);
     update.location = escapeString(location);
 
-    if (saveAllContent) {
-      this.logWithResponseBody(details, update);
-    } else if (saveJavascript && this.isJS(details.type)) {
+    if (this.shouldSaveContent(saveContent, details.type)) {
       this.logWithResponseBody(details, update);
     } else {
       this.dataReceiver.saveRecord("http_responses", update);

--- a/automation/default_browser_params.json
+++ b/automation/default_browser_params.json
@@ -4,8 +4,7 @@
     "js_instrument": false,
     "http_instrument": false,
     "navigation_instrument": false,
-    "save_javascript": false,
-    "save_all_content": false,
+    "save_content": false,
 
     "random_attributes": false,
     "bot_mitigation": false,

--- a/automation/utilities/db_utils.py
+++ b/automation/utilities/db_utils.py
@@ -24,7 +24,7 @@ def query_db(db, query, params=None, as_tuple=False):
     return rows
 
 
-def get_javascript_content(data_directory):
+def get_content(data_directory):
     """Yield key, value pairs from the deduplicated leveldb content database
 
     Parameters

--- a/crawler.py
+++ b/crawler.py
@@ -36,7 +36,12 @@ for i in range(NUM_BROWSERS):
     browser_params[i]['cookie_instrument'] = COOKIE_INSTRUMENT
     browser_params[i]['navigation_instrument'] = NAVIGATION_INSTRUMENT
     browser_params[i]['js_instrument'] = JS_INSTRUMENT
-    browser_params[i]['save_content'] = SAVE_CONTENT
+    if SAVE_CONTENT == '1':
+        browser_params[i]['save_content'] = True
+    elif SAVE_CONTENT == '0':
+        browser_params[i]['save_content'] = False
+    else:
+        browser_params[i]['save_content'] = SAVE_CONTENT
     browser_params[i]['headless'] = True
 
 # Manager configuration

--- a/crawler.py
+++ b/crawler.py
@@ -21,7 +21,7 @@ HTTP_INSTRUMENT = os.getenv('HTTP_INSTRUMENT', '1') == '1'
 COOKIE_INSTRUMENT = os.getenv('COOKIE_INSTRUMENT', '1') == '1'
 NAVIGATION_INSTRUMENT = os.getenv('NAVIGATION_INSTRUMENT', '1') == '1'
 JS_INSTRUMENT = os.getenv('JS_INSTRUMENT', '1') == '1'
-SAVE_JAVASCRIPT = os.getenv('SAVE_JAVASCRIPT', '0') == '1'
+SAVE_CONTENT = os.getenv('SAVE_CONTENT', '')
 DWELL_TIME = int(os.getenv('DWELL_TIME', '10'))
 TIMEOUT = int(os.getenv('TIMEOUT', '60'))
 SENTRY_DSN = os.getenv('SENTRY_DSN', None)
@@ -36,7 +36,7 @@ for i in range(NUM_BROWSERS):
     browser_params[i]['cookie_instrument'] = COOKIE_INSTRUMENT
     browser_params[i]['navigation_instrument'] = NAVIGATION_INSTRUMENT
     browser_params[i]['js_instrument'] = JS_INSTRUMENT
-    browser_params[i]['save_javascript'] = SAVE_JAVASCRIPT
+    browser_params[i]['save_content'] = SAVE_CONTENT
     browser_params[i]['headless'] = True
 
 # Manager configuration
@@ -69,7 +69,7 @@ if SENTRY_DSN:
         scope.set_tag('COOKIE_INSTRUMENT', COOKIE_INSTRUMENT)
         scope.set_tag('NAVIGATION_INSTRUMENT', NAVIGATION_INSTRUMENT)
         scope.set_tag('JS_INSTRUMENT', JS_INSTRUMENT)
-        scope.set_tag('SAVE_JAVASCRIPT', SAVE_JAVASCRIPT)
+        scope.set_tag('SAVE_CONTENT', SAVE_CONTENT)
         scope.set_tag('DWELL_TIME', DWELL_TIME)
         scope.set_tag('TIMEOUT', TIMEOUT)
         scope.set_tag('CRAWL_REFERENCE', '%s/%s' %

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -604,8 +604,9 @@ class TestHTTPInstrument(OpenWPMTest):
     def test_document_saving(self, tmpdir):
         """ check that document content is saved and hashed correctly """
         test_url = utilities.BASE_TEST_URL + '/http_test_page.html'
-        expected_hashes = {'foo',
-                           'bar'}
+        expected_hashes = {
+            '2390eceab422db15bc45940b7e042e83e6cbd5f279f57e714bc4ad6cded7f966',
+            '25343f42d9ffa5c082745f775b172db87d6e14dfbc3160b48669e06d727bfc8d'}
         manager_params, browser_params = self.get_test_config(str(tmpdir))
         browser_params[0]['http_instrument'] = True
         browser_params[0]['save_content'] = "main_frame,sub_frame"

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -425,7 +425,6 @@ class TestHTTPInstrument(OpenWPMTest):
     def get_config(self, data_dir=""):
         manager_params, browser_params = self.get_test_config(data_dir)
         browser_params[0]['http_instrument'] = True
-        browser_params[0]['save_content'] = "script"
         return manager_params, browser_params
 
     def test_page_visit(self):
@@ -585,11 +584,35 @@ class TestHTTPInstrument(OpenWPMTest):
     def test_javascript_saving(self, tmpdir):
         """ check that javascript content is saved and hashed correctly """
         test_url = utilities.BASE_TEST_URL + '/http_test_page.html'
-        self.visit(test_url, str(tmpdir), sleep_after=3)
+        manager_params, browser_params = self.get_test_config(str(tmpdir))
+        browser_params[0]['http_instrument'] = True
+        browser_params[0]['save_content'] = "script"
+        manager = TaskManager.TaskManager(manager_params, browser_params)
+        manager.get(url=test_url, sleep=1)
+        manager.close()
         expected_hashes = {
             '0110c0521088c74f179615cd7c404816816126fa657550032f75ede67a66c7cc',
             'b34744034cd61e139f85f6c4c92464927bed8343a7ac08acf9fb3c6796f80f08'}
-        for chash, content in db_utils.get_javascript_content(str(tmpdir)):
+        for chash, content in db_utils.get_content(str(tmpdir)):
+            chash = chash.decode('ascii').lower()
+            pyhash = sha256(content).hexdigest().lower()
+            assert pyhash == chash  # Verify expected key (sha256 of content)
+            assert chash in expected_hashes
+            expected_hashes.remove(chash)
+        assert len(expected_hashes) == 0  # All expected hashes have been seen
+
+    def test_document_saving(self, tmpdir):
+        """ check that document content is saved and hashed correctly """
+        test_url = utilities.BASE_TEST_URL + '/http_test_page.html'
+        expected_hashes = {'foo',
+                           'bar'}
+        manager_params, browser_params = self.get_test_config(str(tmpdir))
+        browser_params[0]['http_instrument'] = True
+        browser_params[0]['save_content'] = "main_frame,sub_frame"
+        manager = TaskManager.TaskManager(manager_params, browser_params)
+        manager.get(url=test_url, sleep=1)
+        manager.close()
+        for chash, content in db_utils.get_content(str(tmpdir)):
             chash = chash.decode('ascii').lower()
             pyhash = sha256(content).hexdigest().lower()
             assert pyhash == chash  # Verify expected key (sha256 of content)
@@ -620,7 +643,7 @@ class TestHTTPInstrument(OpenWPMTest):
             disk_content[chash] = content
 
         ldb_content = dict()
-        for chash, content in db_utils.get_javascript_content(str(tmpdir)):
+        for chash, content in db_utils.get_content(str(tmpdir)):
             chash = chash.decode('ascii')
             ldb_content[chash] = content
 

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -425,7 +425,7 @@ class TestHTTPInstrument(OpenWPMTest):
     def get_config(self, data_dir=""):
         manager_params, browser_params = self.get_test_config(data_dir)
         browser_params[0]['http_instrument'] = True
-        browser_params[0]['save_javascript'] = True
+        browser_params[0]['save_content'] = "script"
         return manager_params, browser_params
 
     def test_page_visit(self):
@@ -602,7 +602,7 @@ class TestHTTPInstrument(OpenWPMTest):
         test_url = utilities.BASE_TEST_URL + '/http_test_page.html'
         manager_params, browser_params = self.get_test_config(str(tmpdir))
         browser_params[0]['http_instrument'] = True
-        browser_params[0]['save_all_content'] = True
+        browser_params[0]['save_content'] = True
         manager = TaskManager.TaskManager(manager_params, browser_params)
         manager.get(url=test_url, sleep=1)
         manager.close()

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -66,7 +66,7 @@ class TestProfile(OpenWPMTest):
     def test_profile_saved_when_launch_crashes(self):
         manager_params, browser_params = self.get_config()
         browser_params[0]['proxy'] = True
-        browser_params[0]['save_javascript'] = True
+        browser_params[0]['save_content'] = "script"
         manager = TaskManager.TaskManager(manager_params, browser_params)
         manager.get('http://example.com')
 


### PR DESCRIPTION
Fixes #344  

Possible ways to specify "save_content": 
* script,main_frame,sub_frame
* True
* False

But not:
* ['script', 'main_frame', 'sub_frame']
* '0'
* '1'