### PR TITLE
Add config option js_instrument_modules

### DIFF
--- a/automation/Extension/firefox/content.js/index.js
+++ b/automation/Extension/firefox/content.js/index.js
@@ -1,4 +1,4 @@
 import { injectJavascriptInstrumentPageScript } from "openwpm-webext-instrumentation";
 
-const testing = window.openWpmTesting || false;
-injectJavascriptInstrumentPageScript(testing);
+injectJavascriptInstrumentPageScript(window.openWpmContentScriptConfig || {});
+delete window.openWpmContentScriptConfig;

--- a/automation/Extension/firefox/feature.js/index.js
+++ b/automation/Extension/firefox/feature.js/index.js
@@ -21,6 +21,7 @@ async function main() {
       navigation_instrument:true,
       cookie_instrument:true,
       js_instrument:true,
+      js_instrument_modules:"fingerprinting",
       http_instrument:true,
       save_javascript:false,
       save_all_content:false,
@@ -49,7 +50,7 @@ async function main() {
     loggingDB.logDebug("Javascript instrumentation enabled");
     let jsInstrument = new JavascriptInstrument(loggingDB);
     jsInstrument.run(config['crawl_id']);
-    await jsInstrument.registerContentScript(config['testing']);
+    await jsInstrument.registerContentScript(config['testing'], config['js_instrument_modules']);
   }
 
   if (config['http_instrument']) {

--- a/automation/Extension/webext-instrumentation/src/background/javascript-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/javascript-instrument.ts
@@ -110,10 +110,21 @@ export class JavascriptInstrument {
     });
   }
 
-  public async registerContentScript(testing = false) {
-    if (testing) {
+  public async registerContentScript(testing, modules) {
+    const contentScriptConfig = {
+      testing,
+      modules,
+    };
+    if (contentScriptConfig) {
+      // TODO: Avoid using window to pass the content script config
       await browser.contentScripts.register({
-        js: [{ code: "window.openWpmTesting = true;" }],
+        js: [
+          {
+            code: `window.openWpmContentScriptConfig = ${JSON.stringify(
+              contentScriptConfig,
+            )};`,
+          },
+        ],
         matches: ["<all_urls>"],
         allFrames: true,
         runAt: "document_start",

--- a/automation/Extension/webext-instrumentation/src/content/javascript-instrument-content-scope.ts
+++ b/automation/Extension/webext-instrumentation/src/content/javascript-instrument-content-scope.ts
@@ -52,9 +52,9 @@ document.addEventListener(event_id.toString(), function(e: CustomEvent) {
   }
 });
 
-export function injectJavascriptInstrumentPageScript(testing = false) {
+export function injectJavascriptInstrumentPageScript(contentScriptConfig) {
   insertScript(getPageScriptAsString(), {
     event_id,
-    testing,
+    ...contentScriptConfig,
   });
 }

--- a/automation/Extension/webext-instrumentation/src/content/javascript-instrument-page-scope.ts
+++ b/automation/Extension/webext-instrumentation/src/content/javascript-instrument-page-scope.ts
@@ -32,13 +32,21 @@ export const pageScript = function({
   /*
    * Start Instrumentation
    */
-  // TODO: user should be able to choose what to instrument
+  const modules = document.currentScript.getAttribute("data-modules")
+    ? document.currentScript.getAttribute("data-modules").split(",")
+    : [];
 
-  instrumentFingerprintingApis({ instrumentObjectProperty, instrumentObject });
+  if (modules.includes("fingerprinting")) {
+    instrumentFingerprintingApis({
+      instrumentObjectProperty,
+      instrumentObject,
+    });
+  }
 
   if (testing) {
     console.log(
       "OpenWPM: Content-side javascript instrumentation started",
+      { modules },
       new Date().toISOString(),
     );
   }

--- a/automation/default_browser_params.json
+++ b/automation/default_browser_params.json
@@ -2,6 +2,7 @@
     "extension_enabled": true,
     "cookie_instrument": false,
     "js_instrument": false,
+    "js_instrument_modules": "fingerprinting",
     "http_instrument": false,
     "navigation_instrument": false,
     "save_javascript": false,


### PR DESCRIPTION
... with default value "fingerprinting" for instrumenting fingerprinting-related apis.

This is a step towards https://github.com/mozilla/OpenWPM/issues/353, allowing custom instrumentation to be implemented without having to comment out the fingerprinting-related api:s, which breaks many of the tests.