### PR TITLE
Js instrument retain prototype and constructor

### DIFF
--- a/automation/Extension/webext-instrumentation/src/lib/js-instruments.ts
+++ b/automation/Extension/webext-instrumentation/src/lib/js-instruments.ts
@@ -609,12 +609,21 @@ export function jsInstruments(event_id, sendMessagesToLogger) {
                 logSettings,
               );
             }
-            return instrumentFunction(
+            const instrumentedFunctionWrapper = instrumentFunction(
               objectName,
               propertyName,
               origProperty,
               logSettings,
             );
+            // Restore the original prototype and constructor so that instrumented classes remain intact
+            if (origProperty.prototype) {
+              instrumentedFunctionWrapper.prototype = origProperty.prototype;
+              if (origProperty.prototype.constructor) {
+                instrumentedFunctionWrapper.prototype.constructor =
+                  origProperty.prototype.constructor;
+              }
+            }
+            return instrumentedFunctionWrapper;
           } else if (
             typeof origProperty === "object" &&
             !!logSettings.recursive &&


### PR DESCRIPTION
Restore the original prototype and constructor so that instrumented classes remain intact.

Fixes #461

This PR currently also includes https://github.com/mozilla/OpenWPM/pull/458, will be rebased after its merge.