### PR TITLE
Top-Level-Url attribution for HTTP-Requests

### DIFF
--- a/automation/Extension/webext-instrumentation/package.json
+++ b/automation/Extension/webext-instrumentation/package.json
@@ -20,7 +20,7 @@
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:tslint": "tslint -t verbose --fix --project .",
     "test": "run-s build test:*",
-    "test:lint": "echo 'nolint'",
+    "test:lint": "tslint -t verbose --project . && prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc ava",
     "test:unit:verbose": "nyc ava --verbose --serial",
     "watch": "run-s clean build:main && run-p \"build:main -- -w\" \"test:unit -- --watch\"",

--- a/automation/Extension/webext-instrumentation/package.json
+++ b/automation/Extension/webext-instrumentation/package.json
@@ -20,7 +20,7 @@
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:tslint": "tslint -t verbose --fix --project .",
     "test": "run-s build test:*",
-    "test:lint": "tslint -t verbose --project . && prettier \"src/**/*.ts\" --list-different",
+    "test:lint": "echo 'nolint'",
     "test:unit": "nyc ava",
     "test:unit:verbose": "nyc ava --verbose --serial",
     "watch": "run-s clean build:main && run-p \"build:main -- -w\" \"test:unit -- --watch\"",

--- a/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
@@ -490,7 +490,7 @@ export class HttpInstrument {
    * @return {?String} the URL for the request's top-level document
    */
   private getDocumentUrlForRequest(
-    details: WebRequestOnBeforeSendHeadersEventDetails
+    details: WebRequestOnBeforeSendHeadersEventDetails,
   ) {
     let url = "";
 

--- a/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
@@ -468,7 +468,7 @@ export class HttpInstrument {
       }
     }
     */
-    update.top_level_url = this.getDocumentUrlForRequest(details);
+    update.top_level_url = escapeUrl(this.getDocumentUrlForRequest(details));
     update.parent_frame_id = details.parentFrameId;
     update.frame_ancestors = escapeString(
       JSON.stringify(details.frameAncestors),
@@ -485,11 +485,13 @@ export class HttpInstrument {
    * The request's document may be different from the current top-level document
    * loaded in tab as requests can come out of order:
    *
-   * @param {Object} details chrome.webRequest request/response details object
+   * @param {WebRequestOnBeforeSendHeadersEventDetails} details
    *
    * @return {?String} the URL for the request's top-level document
    */
-  private getDocumentUrlForRequest(details) {
+  private getDocumentUrlForRequest(
+    details: WebRequestOnBeforeSendHeadersEventDetails
+  ) {
     let url = "";
 
     if (details.type === "main_frame") {

--- a/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
+++ b/automation/Extension/webext-instrumentation/src/background/http-instrument.ts
@@ -94,7 +94,6 @@ export class HttpInstrument {
       if (this.shouldSaveContent(saveContentOption, details.type)) {
         pendingResponse.addResponseResponseBodyListener(details);
       }
-      console.log("Frame ancestors: ", JSON.stringify(details.frameAncestors));
       return blockingResponseThatDoesNothing;
     };
     browser.webRequest.onBeforeRequest.addListener(
@@ -469,13 +468,11 @@ export class HttpInstrument {
       }
     }
     */
-    // update.top_level_url = escapeUrl(tab.url);
     update.top_level_url = this.getDocumentUrlForRequest(details);
     update.parent_frame_id = details.parentFrameId;
     update.frame_ancestors = escapeString(
       JSON.stringify(details.frameAncestors),
     );
-    console.log("Frame ancestors: ", JSON.stringify(details.frameAncestors));
     this.dataReceiver.saveRecord("http_requests", update);
   }
 
@@ -515,8 +512,6 @@ export class HttpInstrument {
           url = details.documentUrl;
         }
       }
-    } else {
-      url = "something";
     }
     return url;
   }

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -406,21 +406,6 @@ CALL_STACK_INJECT_IMAGE =\
 
 BASE_PATH = os.path.dirname(os.path.realpath(__file__))
 
-
-# HACK: sometimes the browser has time to load about:blank
-# before getting our load request, so the top level URL is
-# logged as about:blank.
-# In this case, manually replace that value with the test
-# page URL.
-# Issue #245 tracks the issue of incorrect top level urls.
-def fix_about_page_url(url):
-    if url == "about:blank":
-        return url
-        # return u'http://localtest.me:8000/test_pages/http_test_page.html'
-    else:
-        return url
-
-
 class TestHTTPInstrument(OpenWPMTest):
 
     def get_config(self, data_dir=""):
@@ -440,7 +425,7 @@ class TestHTTPInstrument(OpenWPMTest):
         for row in rows:
             observed_records.add((
                 row['url'].split('?')[0],
-                fix_about_page_url(row['top_level_url']),
+                row['top_level_url'],
                 row['triggering_origin'], row['loading_origin'],
                 row['loading_href'], row['is_XHR'],
                 row['is_frame_load'], row['is_full_page'],
@@ -509,7 +494,7 @@ class TestHTTPInstrument(OpenWPMTest):
                 continue
             observed_records.add((
                 row['url'].split('?')[0],
-                fix_about_page_url(row['top_level_url']),
+                row['top_level_url'],
                 row['triggering_origin'], row['loading_origin'],
                 row['loading_href'], row['is_XHR'],
                 row['is_frame_load'], row['is_full_page'],

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -415,7 +415,8 @@ BASE_PATH = os.path.dirname(os.path.realpath(__file__))
 # Issue #245 tracks the issue of incorrect top level urls.
 def fix_about_page_url(url):
     if url == "about:blank":
-        return u'http://localtest.me:8000/test_pages/http_test_page.html'
+        return url
+        # return u'http://localtest.me:8000/test_pages/http_test_page.html'
     else:
         return url
 

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -406,6 +406,7 @@ CALL_STACK_INJECT_IMAGE =\
 
 BASE_PATH = os.path.dirname(os.path.realpath(__file__))
 
+
 class TestHTTPInstrument(OpenWPMTest):
 
     def get_config(self, data_dir=""):


### PR DESCRIPTION
I call this work-in-progress because I'm not sure this is exactly what we want for Issue #245, although if it is, this might be close to a working fix.
Contrary to what is mentioned in #245 I didn't need to switch the listener to onBeforeRequest, since frameAncestors are also available in the onBeforeSendHeaders details object. 

I borrowed heavily from the work on this issue in privacy badger, only stripped their solution down to what I think we need for our purpose. I'm not entirely sure the four cases in my function cover all possible types of requests, but they are the ones I could identify through spec research and experiments.

This currently gives the entire URL for a given document, not only the host. That is especially true for service workers, where the returned URL might not match the URL dispalyed in the associated tab in the browser. Is that the intended behaviour?