### PR TITLE
Improved browser error logging in crawl_history

### DIFF
--- a/automation/BrowserManager.py
+++ b/automation/BrowserManager.py
@@ -12,6 +12,7 @@ import traceback
 
 import psutil
 from multiprocess import Queue
+from selenium.common.exceptions import WebDriverException
 from six import reraise
 from six.moves import cPickle as pickle
 from six.moves.queue import Empty as EmptyQueue
@@ -478,16 +479,33 @@ def BrowserManager(command_queue, status_queue, browser_params,
             # attempts to perform an action and return an OK signal
             # if command fails for whatever reason, tell the TaskManager to
             # kill and restart its worker processes
-            command_executor.execute_command(
-                command, driver, browser_settings,
-                browser_params, manager_params, extension_socket)
-            status_queue.put("OK")
+            try:
+                command_executor.execute_command(
+                    command, driver, browser_settings,
+                    browser_params, manager_params, extension_socket)
+                status_queue.put("OK")
+            except WebDriverException:
+                # We handle WebDriverExceptions separately here because they
+                # are quite common, and we often still have a handle to the
+                # browser, allowing us to run the SHUTDOWN command.
+                tb = traceback.format_exception(*sys.exc_info())
+                if 'about:neterror' in tb[-1]:
+                    status_queue.put(
+                        ('NETERROR', pickle.dumps(sys.exc_info()))
+                    )
+                    continue
+                extra = parse_traceback_for_sentry(tb)
+                extra['exception'] = tb[-1]
+                logger.error(
+                    "BROWSER %i: WebDriverException while executing command" %
+                    browser_params['crawl_id'], exc_info=True, extra=extra
+                )
+                status_queue.put(('FAILED', pickle.dumps(sys.exc_info())))
 
     except (ProfileLoadError, BrowserConfigError, AssertionError) as e:
         logger.error("BROWSER %i: %s thrown, informing parent and raising" % (
             browser_params['crawl_id'], e.__class__.__name__))
-        err_info = sys.exc_info()
-        status_queue.put(('CRITICAL', pickle.dumps(err_info)))
+        status_queue.put(('CRITICAL', pickle.dumps(sys.exc_info())))
         return
     except Exception:
         tb = traceback.format_exception(*sys.exc_info())
@@ -497,5 +515,5 @@ def BrowserManager(command_queue, status_queue, browser_params,
             "BROWSER %i: Crash in driver, restarting browser manager" %
             browser_params['crawl_id'], exc_info=True, extra=extra
         )
-        status_queue.put(('FAILED', None))
+        status_queue.put(('FAILED', pickle.dumps(sys.exc_info())))
         return

--- a/automation/Commands/browser_commands.py
+++ b/automation/Commands/browser_commands.py
@@ -21,10 +21,10 @@ from six.moves import range
 
 from ..SocketInterface import clientsocket
 from .utils.lso import get_flash_cookies
-from .utils.webdriver_extensions import (execute_in_all_frames,
-                                         execute_script_with_retry,
-                                         get_intra_links, is_displayed,
-                                         scroll_down, wait_until_loaded)
+from .utils.webdriver_utils import (execute_in_all_frames,
+                                    execute_script_with_retry, get_intra_links,
+                                    is_displayed, scroll_down,
+                                    wait_until_loaded)
 
 # Constants for bot mitigation
 NUM_MOUSE_MOVES = 10  # Times to randomly move the mouse

--- a/automation/Commands/utils/webdriver_utils.py
+++ b/automation/Commands/utils/webdriver_utils.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import random
+import re
 import time
 
 from selenium.common.exceptions import (ElementNotVisibleException,
@@ -13,12 +14,27 @@ from selenium.common.exceptions import (ElementNotVisibleException,
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib import parse as urlparse
 
 from ...utilities import domain_utils as du
 from . import XPathUtil
 
-# Basic functions
+NETERROR_RE = re.compile(
+    r"WebDriverException: Message: Reached error page: about:neterror\?(.*)\."
+)
+
+
+def parse_neterror(error_message):
+    """Attempt to parse the about:neterror message.
+
+    If any errors occur while parsing, we fall back to the unparsed message
+    """
+    try:
+        qs = re.match(NETERROR_RE, error_message).group(1)
+        params = urlparse.parse_qs(qs)
+        return '&'.join(params['e'])
+    except Exception:
+        return error_message
 
 
 def scroll_down(driver):
@@ -67,7 +83,7 @@ def get_intra_links(webdriver, url):
             continue
         if href is None:
             continue
-        full_href = urljoin(url, href)
+        full_href = urlparse.urljoin(url, href)
         if not full_href.startswith('http'):
             continue
         if du.get_ps_plus_1(full_href) == ps1:

--- a/automation/DataAggregator/parquet_schema.py
+++ b/automation/DataAggregator/parquet_schema.py
@@ -32,7 +32,9 @@ fields = [
     pa.field('command', pa.string()),
     pa.field('arguments', pa.string()),
     pa.field('retry_number', pa.int8()),
-    pa.field('bool_success', pa.int8()),
+    pa.field('command_status', pa.string()),
+    pa.field('error', pa.string()),
+    pa.field('traceback', pa.string())
 ]
 PQ_SCHEMAS['crawl_history'] = pa.schema(fields)
 

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -457,7 +457,6 @@ class TaskManager:
             browser.current_timeout = timeout
             # passes off command and waits for a success (or failure signal)
             browser.command_queue.put(command)
-            command_succeeded = 0  # 1 success, 0 error, -1 timeout
             command_arguments = command[1] if len(command) > 1 else None
 
             # received reply from BrowserManager, either success or failure
@@ -520,7 +519,7 @@ class TaskManager:
             if critical_failure:
                 return
 
-            if command_succeeded != 1:
+            if command_status != 'ok':
                 with self.threadlock:
                     self.failurecount += 1
                 if self.failurecount > self.failure_limit:

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -6,22 +6,24 @@ import logging
 import os
 import threading
 import time
+import traceback
 
 import psutil
+import tblib
 from six import reraise
 from six.moves import cPickle as pickle
 from six.moves import range
 from six.moves.queue import Empty as EmptyQueue
-from tblib import pickling_support
 
 from . import CommandSequence, MPLogger
 from .BrowserManager import Browser
+from .Commands.utils.webdriver_utils import parse_neterror
 from .DataAggregator import LocalAggregator, S3Aggregator
 from .Errors import CommandExecutionError
 from .SocketInterface import clientsocket
 from .utilities.platform_utils import get_configuration_string, get_version
 
-pickling_support.install()
+tblib.pickling_support.install()
 
 SLEEP_CONS = 0.1  # command sleep constant (in seconds)
 BROWSER_MEMORY_LIMIT = 1500  # in MB
@@ -410,6 +412,13 @@ class TaskManager:
         thread.start()
         return thread
 
+    def _unpack_picked_error(self, pickled_error):
+        """Unpacks `pickled_error` into and error `message` and `tb` string."""
+        exc = pickle.loads(pickled_error)
+        message = traceback.format_exception(*exc)[-1]
+        tb = json.dumps(tblib.Traceback(exc[2]).to_dict())
+        return message, tb
+
     def _issue_command(self, browser, command_sequence, condition=None):
         """
         sends command tuple to the BrowserManager
@@ -452,11 +461,14 @@ class TaskManager:
             command_arguments = command[1] if len(command) > 1 else None
 
             # received reply from BrowserManager, either success or failure
+            critical_failure = False
+            error_text = None
+            tb = None
             try:
                 status = browser.status_queue.get(
                     True, browser.current_timeout)
                 if status == "OK":
-                    command_succeeded = 1
+                    command_status = 'ok'
                 elif status[0] == "CRITICAL":
                     self.logger.critical(
                         "BROWSER %i: Received critical error from browser "
@@ -467,14 +479,29 @@ class TaskManager:
                         'CommandSequence': command_sequence,
                         'Exception': status[1]
                     }
-                    return
-                else:
-                    command_succeeded = 0
+                    error_text, tb = self._unpack_picked_error(status[1])
+                    critical_failure = True
+                elif status[0] == "FAILED":
+                    command_status = 'error'
+                    error_text, tb = self._unpack_picked_error(status[1])
                     self.logger.info(
                         "BROWSER %i: Received failure status while executing "
                         "command: %s" % (browser.crawl_id, command[0]))
+                elif status[0] == 'NETERROR':
+                    command_status = 'neterror'
+                    error_text, tb = self._unpack_picked_error(status[1])
+                    error_text = parse_neterror(error_text)
+                    self.logger.info(
+                        "BROWSER %i: Received neterror %s while executing "
+                        "command: %s" %
+                        (browser.crawl_id, error_text, command[0])
+                    )
+                else:
+                    raise ValueError(
+                        "Unknown browser status message %s" % status
+                    )
             except EmptyQueue:
-                command_succeeded = -1
+                command_status = 'timeout'
                 self.logger.info(
                     "BROWSER %i: Timeout while executing command, %s, killing "
                     "browser manager" % (browser.crawl_id, command[0]))
@@ -485,8 +512,13 @@ class TaskManager:
                 "command": command[0],
                 "arguments": str(command_arguments),
                 "retry_number": command_sequence.retry_number,
-                "bool_success": command_succeeded
+                "command_status": command_status,
+                "error": error_text,
+                "traceback": tb
             }))
+
+            if critical_failure:
+                return
 
             if command_succeeded != 1:
                 with self.threadlock:

--- a/automation/schema.sql
+++ b/automation/schema.sql
@@ -50,7 +50,9 @@ CREATE TABLE IF NOT EXISTS crawl_history (
     command TEXT,
     arguments TEXT,
     retry_number INTEGER,
-    bool_success INTEGER,
+    command_status TEXT,
+    error TEXT,
+    traceback TEXT,
     dtg DATETIME DEFAULT (CURRENT_TIMESTAMP),
     FOREIGN KEY(crawl_id) REFERENCES crawl(id));
 

--- a/automation/utilities/db_utils.py
+++ b/automation/utilities/db_utils.py
@@ -55,6 +55,6 @@ def any_command_failed(db):
     """Returns True if any command in a given database failed"""
     rows = query_db(db, "SELECT * FROM crawl_history;")
     for row in rows:
-        if row['bool_success'] != 1:
+        if row['command_status'] != 'ok':
             return True
     return False

--- a/test/manual_test.py
+++ b/test/manual_test.py
@@ -17,7 +17,7 @@ from .utilities import BASE_TEST_URL, start_server
 
 # import commonly used modules and utilities so they can be easily accessed
 # in the interactive session
-from automation.Commands.utils import webdriver_extensions as wd_ext  # noqa isort:skip
+from automation.Commands.utils import webdriver_utils as wd_util  # noqa isort:skip
 from automation.utilities import domain_utils as du  # noqa isort:skip
 from selenium.webdriver.common.keys import Keys  # noqa isort:skip
 from selenium.common.exceptions import *  # noqa isort:skip

--- a/test/test_crawl.py
+++ b/test/test_crawl.py
@@ -86,13 +86,13 @@ class TestCrawl(OpenWPMTest):
             req_ps.add(psl.get_public_suffix(urlparse(url).hostname))
 
         hist_ps = set()  # visited domains from crawl_history Table
-        successes = dict()
-        rows = db_utils.query_db(crawl_db, "SELECT arguments, bool_success "
+        statuses = dict()
+        rows = db_utils.query_db(crawl_db, "SELECT arguments, command_status "
                                  "FROM crawl_history WHERE command='GET'")
-        for url, success in rows:
+        for url, command_status in rows:
             ps = psl.get_public_suffix(urlparse(url).hostname)
             hist_ps.add(ps)
-            successes[ps] = success
+            statuses[ps] = command_status
 
         # Grab urls from Firefox database
         profile_ps = set()  # visited domains from firefox profile
@@ -112,7 +112,7 @@ class TestCrawl(OpenWPMTest):
         missing_urls = req_ps.intersection(hist_ps).difference(profile_ps)
         unexpected_missing_urls = set()
         for url in missing_urls:
-            if successes[url] == 0 or successes[url] == -1:
+            if command_status[url] != 'ok':
                 continue
 
             # Get the visit id for the url


### PR DESCRIPTION
This contains the changes in #468, will rebase once that merges.

This PR includes several improvements to error logging:
1. `bool_success` has been removed from the `crawl_history` table and replaced by `command_status`, which is a string.
    1. Successful commands use `"ok"`
    2. Exceptions in the browser manager process use `"error"`
    3. `about:neterror` WebDriverExceptions are special cased, and use `"neterror"`
    4. Timeouts use `"timeout"`
2. Error messages and full, serialized tracebacks are included in the `crawl_history` table in the columns `error` and `traceback`. The error message for `about:neterror` exceptions parses out the exact error from the `about:` url -- e.g., `dnsError`.
3. `about:neterror` exceptions now log at the `logging.INFO` level, so they should not be included in Sentry to cut down on noise.

A sample from a very small, 10 site crawl is available here: https://dbc-caf9527b-e073.cloud.databricks.com/#notebook/154881/command/154898.