### PR TITLE
Add page visit test including a worker script making a request

### DIFF
--- a/test/test_pages/http_service_worker_page.html
+++ b/test/test_pages/http_service_worker_page.html
@@ -1,0 +1,45 @@
+<html>
+  <head>
+    <title>HTTP Test page including a service worker</title>
+    <link rel='icon' href='shared/test_favicon.ico' />
+  </head>
+  <body>
+    <p> This test page registers a service worker, then sends a message
+    to the worker to tell it to make a request.
+    </p>
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register(
+          './shared/service_worker.js',
+          {scope: './shared/'}
+        ).then((reg) => {
+          // registration worked
+          console.log('Registration succeeded. Scope is ' + reg.scope);
+          var serviceWorker;
+          if (reg.installing) {
+            serviceWorker = reg.installing;
+          } else if (reg.waiting) {
+            serviceWorker = reg.waiting;
+          } else if (reg.active) {
+            serviceWorker = reg.active;
+          }
+          serviceWorker.addEventListener('statechange', (e) => {
+            // Send message to service worker to trigger image load.
+            if (e.target.state === 'activated') {
+              reg.active.postMessage("Fetch image.");
+            }
+          })
+        }).catch((error) => {
+          // registration failed
+          console.log('Registration failed with ' + error);
+        });
+      }
+    </script>
+    <script>
+      var request = new Request(
+        'http://localhost:8000/test_pages/shared/test_image.png'
+      );
+      fetch(request);
+    </script>
+  </body>
+</html>

--- a/test/test_pages/http_worker_page.html
+++ b/test/test_pages/http_worker_page.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <title>HTTP Test page including a worker</title>
+    <link rel='icon' href='shared/test_favicon.ico' />
+  </head>
+  <body>
+    <p> This test page spawns a worker, which in turn makes
+    http-requests on its own.
+    </p>
+    <script>
+      let worker = new Worker("./shared/worker.js");
+    </script>
+    <script src="./shared/worker.js"></script>
+  </body>
+</html>

--- a/test/test_pages/shared/service_worker.js
+++ b/test/test_pages/shared/service_worker.js
@@ -1,0 +1,8 @@
+var request = new Request(
+  'http://localhost:8000/test_pages/shared/test_image_2.png'
+);
+
+self.addEventListener('message', function(event) {
+  console.log("Service Worker received message. Fetches image.")
+  fetch(request);
+});

--- a/test/test_pages/shared/worker.js
+++ b/test/test_pages/shared/worker.js
@@ -1,0 +1,6 @@
+
+const request = new Request(
+  'http://localtest.me:8000/test_pages/shared/test_image.png'
+);
+
+fetch(request);


### PR DESCRIPTION
This patch adds a new testcase for the http instrumentation. 
A page is loaded that includes a worker script. The page and the script both load the same image, resulting in different requests with differen top-level-urls. 
As mentioned [here](https://github.com/mozilla/OpenWPM/pull/469#discussion_r321275524), I'm not sure this behaviour is actually desired. The request made by the script would have been attributed to the page's URL before [PR#469](https://github.com/mozilla/OpenWPM/pull/469), now it gets the URL of the script itself. The URL-attribution code might need to be adapted to handle requests by worker scripts differently.
Also, as mentioned, I wasn't able to create a similar test for a page with a Service Worker because that would reuqire the page to be served over https. 

