### PR TITLE
Update localstack to newest version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 autopep8
-localstack==0.9.6
+localstack

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 autopep8
 localstack
+requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 autopep8
-localstack
-requests
+localstack[full]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ IPython>=5.0; python_version >= '3.0'
 mini-amf
 mmh3
 multiprocess
-numpy>=1.14
+numpy
 pandas
 pillow
 plyvel
@@ -23,7 +23,7 @@ python-dateutil
 redis
 s3fs
 selenium
-sentry-sdk==0.10.2
+sentry-sdk
 setuptools
 six
 tabulate

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -25,7 +25,7 @@ class TestDependencies(OpenWPMTest):
             line = line.strip()
             if line == "" or line[0] == "#":
                 continue
-            pkg = re.split(r'[>=<]', line)[0]
+            pkg = re.split(r'[>=<\[]', line)[0]
             print("Checking Python package", pkg)
             self.assert_py_pkg_installed(pkg)
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -25,6 +25,7 @@ class TestDependencies(OpenWPMTest):
             line = line.strip()
             if line == "" or line[0] == "#":
                 continue
+            # Extract the package name by stripping requirement specifiers
             pkg = re.split(r'[>=<\[]', line)[0]
             print("Checking Python package", pkg)
             self.assert_py_pkg_installed(pkg)


### PR DESCRIPTION
The S3Aggregator tests are failing again, but we didn't make any recent changes. I suspect this is due to `localstack` dependency issues, though I'm unable to reproduce the failures locally. Let's try removing the pin to an old version.