### PR TITLE
Removed one mention of python2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,10 +538,8 @@ Then you can run the demo script using:
 ```
     mkdir -p docker-volume && docker run -v $PWD/docker-volume:/root/Desktop \
     -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --shm-size=2g \
-    -it openwpm python /opt/OpenWPM/demo.py
+    -it openwpm python3 /opt/OpenWPM/demo.py
 ```
-
-Instead of _python_, _python3_ can be used here as well.
 
 **Note:** the `--shm-size=2g` parameter is required, as it increases the
 amount of shared memory available to Firefox. Without this parameter you can


### PR DESCRIPTION
Removed it under "Running Measurements from inside the Container" as the instruction wasn't working anymore.
Closes #513