### PR TITLE
Spoof `navigator.webdriver` to `false`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,4 @@ automation/Extension/firefox/dist
 automation/Extension/firefox/openwpm.xpi
 automation/Extension/firefox/src/content.js
 automation/Extension/firefox/src/feature.js
+automation/Extension/firefox/src/spoof.js

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ automation/Extension/firefox/dist
 automation/Extension/firefox/openwpm.xpi
 automation/Extension/firefox/src/content.js
 automation/Extension/firefox/src/feature.js
+automation/Extension/firefox/src/spoof.js

--- a/LICENSE
+++ b/LICENSE
@@ -41,6 +41,11 @@ https://github.com/redline13/selenium-jmeter
 By Richard Friedman
 Licensed GPLv3+
 
+Incorporating code from User Agent Switcher
+https://gitlab.com/ntninja/user-agent-switcher/
+Copyright © 2017 – 2019  Alexander Schlarb
+Licensed GPLv3+
+
 Text of GPLv3 License:
 ======================
                     GNU GENERAL PUBLIC LICENSE

--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ left out of this section.
   * **NOT SUPPORTED.** See [#101](https://github.com/citp/OpenWPM/issues/101).
   * Set to `True` to enable Firefox's built-in
     [Tracking Protection](https://developer.mozilla.org/en-US/Firefox/Privacy/Tracking_Protection).
+* `spoof_navigator`
+  * Set to `True` to spoof the JavaScript DOM attribute `webdriver` to be `false`.
 
 Browser Profile Support
 -----------------------

--- a/automation/Extension/firefox/feature.js/index.js
+++ b/automation/Extension/firefox/feature.js/index.js
@@ -22,6 +22,7 @@ async function main() {
       js_instrument:true,
       js_instrument_modules:"fingerprinting",
       http_instrument:true,
+      spoof_navigator:false,
       save_content:false,
       testing:true,
       crawl_id:0
@@ -60,9 +61,11 @@ async function main() {
                        config['save_content']);
   }
 
-  loggingDB.logDebug("Now spoofing `webdriver` attribute to `false`"); // TODO Add config option
-  let spoofNavigator = new SpoofNavigator();
-  await spoofNavigator.registerContentScript();
+  if (config['spoof_navigator']) {
+    loggingDB.logDebug("Now spoofing `webdriver` attribute to `false`");
+    let spoofNavigator = new SpoofNavigator();
+    await spoofNavigator.registerContentScript();
+  }
 }
 
 main();

--- a/automation/Extension/firefox/feature.js/index.js
+++ b/automation/Extension/firefox/feature.js/index.js
@@ -3,6 +3,7 @@ import {
   JavascriptInstrument,
   HttpInstrument,
   NavigationInstrument,
+  SpoofNavigator,
 } from "openwpm-webext-instrumentation";
 
 import * as loggingDB from "./loggingdb.js";
@@ -58,6 +59,10 @@ async function main() {
     httpInstrument.run(config['crawl_id'],
                        config['save_content']);
   }
+
+  loggingDB.logDebug("Now spoofing `webdriver` attribute to `false`"); // TODO Add config option
+  let spoofNavigator = new SpoofNavigator();
+  await spoofNavigator.registerContentScript();
 }
 
 main();

--- a/automation/Extension/firefox/spoof.js/index.js
+++ b/automation/Extension/firefox/spoof.js/index.js
@@ -1,0 +1,1 @@
+console.log("CODE WOULD BE EXECUTED");

--- a/automation/Extension/firefox/spoof.js/index.js
+++ b/automation/Extension/firefox/spoof.js/index.js
@@ -1,1 +1,74 @@
-console.log("CODE WOULD BE EXECUTED");
+/*
+/* This code to spoof values of the `window.navigator` object using a
+ * JavaScript proxy is based on:
+ * User Agent Switcher
+ * Copyright © 2017 – 2019  Alexander Schlarb (https://gitlab.com/ntninja)
+/* For the used part see: https://gitlab.com/ntninja/user-agent-switcher/blob/6aacc15ed6651317776f7abb3a85d6f34fc1a254/content/override-navigator-data.js
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Set of all object that we have already proxied to prevent them from being
+ * proxied twice.
+ */
+let proxiedObjects = new Set();
+
+/**
+ * Convenience wrapped around `cloneInto` that enables all possible cloning
+ * options by default.
+ */
+function cloneIntoFull(value, scope) {
+  return cloneInto(value, scope, {
+    cloneFunctions: true,
+    wrapReflectors: true
+  });
+}
+
+/**
+ * Spoof `navigator` by overwriting the `navigator` of the given
+ * (content script scope) `window` object with a proxy, if applicable.
+ */
+function spoofNavigator(window) {
+  if (!(window instanceof Window)) { // Not actually a window object
+    return window;
+  }
+
+  let origNavigator = window.navigator.wrappedJSObject; // `navigator` of the page scope
+  if (proxiedObjects.has(origNavigator)) { // Window was already shadowed
+    return window;
+  }
+
+  let spoofedGet_PageScope = cloneIntoFull({
+    get: (target, prop, receiver) => {
+      if (prop === "webdriver") {
+        return false;
+      } else {
+        return Reflect.get(origNavigator, prop);
+      }
+    }
+  }, window.wrappedJSObject); // The `get` function, defined in privileged code (that is here in the extension / content script), is cloned into the target scope (that is the web page / `window.wrappedJSObject`) and thus accessible there. The return value is the reference to the cloned object in the defined scope.
+
+  let origProxy = window.wrappedJSObject.Proxy;
+  let navigatorProxy = new origProxy(origNavigator, spoofedGet_PageScope);
+
+  proxiedObjects.add(origNavigator);
+
+  let returnFunc_PageScope = exportFunction(() => {
+    return navigatorProxy;
+  }, window.wrappedJSObject);
+  // Using `__defineGetter__` here our function gets assigned the correct
+  // name of `get navigator`. Additionally its property descriptor has
+  // no `set` function and will silently ignore any assigned value. – This
+  // exact configuration is not achievable using `Object.defineProperty`.
+  Object.prototype.__defineGetter__.call(window.wrappedJSObject, "navigator", returnFunc_PageScope);
+  return window;
+}
+
+spoofNavigator(window);

--- a/automation/Extension/firefox/webpack.config.js
+++ b/automation/Extension/firefox/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
   entry: {
     feature: "./feature.js/index.js",
     content: "./content.js/index.js",
+    spoof:   "./spoof.js/index.js",
   },
   output: {
     path: path.resolve(__dirname, "src"),

--- a/automation/Extension/webext-instrumentation/src/background/spoof-navigator.ts
+++ b/automation/Extension/webext-instrumentation/src/background/spoof-navigator.ts
@@ -1,0 +1,16 @@
+export class SpoofNavigator {
+  /**
+   * Dynamically register the content script to proxy
+   * `window.navigator`. The proxy object returns `false`
+   * for the `window.navigator.webdriver` attribute.
+   */
+  public async registerContentScript() {
+    return browser.contentScripts.register({
+      js: [{ file: "/spoof.js" }],
+      matches: ["<all_urls>"],
+      allFrames: true,
+      runAt: "document_start",
+      matchAboutBlank: true,
+    });
+  }
+}

--- a/automation/Extension/webext-instrumentation/src/index.ts
+++ b/automation/Extension/webext-instrumentation/src/index.ts
@@ -2,6 +2,7 @@ export * from "./background/cookie-instrument";
 export * from "./background/http-instrument";
 export * from "./background/javascript-instrument";
 export * from "./background/navigation-instrument";
+export * from "./background/spoof-navigator";
 export * from "./content/javascript-instrument-content-scope";
 export * from "./lib/http-post-parser";
 export * from "./lib/string-utils";

--- a/automation/default_browser_params.json
+++ b/automation/default_browser_params.json
@@ -5,6 +5,7 @@
     "js_instrument_modules": "fingerprinting",
     "http_instrument": false,
     "navigation_instrument": false,
+    "spoof_navigator": false,
     "save_content": false,
 
     "random_attributes": false,

--- a/crawler.py
+++ b/crawler.py
@@ -20,6 +20,7 @@ HTTP_INSTRUMENT = os.getenv('HTTP_INSTRUMENT', '1') == '1'
 COOKIE_INSTRUMENT = os.getenv('COOKIE_INSTRUMENT', '1') == '1'
 NAVIGATION_INSTRUMENT = os.getenv('NAVIGATION_INSTRUMENT', '1') == '1'
 JS_INSTRUMENT = os.getenv('JS_INSTRUMENT', '1') == '1'
+SPOOF_NAVIGATOR = os.getenv('SPOOF_NAVIGATOR', '1') == '1'
 JS_INSTRUMENT_MODULES = os.getenv('JS_INSTRUMENT_MODULES', None)
 SAVE_CONTENT = os.getenv('SAVE_CONTENT', '')
 DWELL_TIME = int(os.getenv('DWELL_TIME', '10'))
@@ -41,6 +42,7 @@ for i in range(NUM_BROWSERS):
     browser_params[i]['cookie_instrument'] = COOKIE_INSTRUMENT
     browser_params[i]['navigation_instrument'] = NAVIGATION_INSTRUMENT
     browser_params[i]['js_instrument'] = JS_INSTRUMENT
+    browser_params[i]['spoof_navigator'] = SPOOF_NAVIGATOR
     if JS_INSTRUMENT_MODULES:
         browser_params[i]['js_instrument_modules'] = JS_INSTRUMENT_MODULES
     if SAVE_CONTENT == '1':
@@ -81,6 +83,7 @@ if SENTRY_DSN:
         scope.set_tag('COOKIE_INSTRUMENT', COOKIE_INSTRUMENT)
         scope.set_tag('NAVIGATION_INSTRUMENT', NAVIGATION_INSTRUMENT)
         scope.set_tag('JS_INSTRUMENT', JS_INSTRUMENT)
+        scope.set_tag('SPOOF_NAVIGATOR', SPOOF_NAVIGATOR)
         scope.set_tag('JS_INSTRUMENT_MODULES', JS_INSTRUMENT)
         scope.set_tag('SAVE_CONTENT', SAVE_CONTENT)
         scope.set_tag('DWELL_TIME', DWELL_TIME)


### PR DESCRIPTION
### What?
Regarding to  #448 this PR extends the OpenWPM instrumentation extension (WebExtension) to spoof the `navigator.webdriver` attribute to `false`. This is done by overwriting `window.navigator` with a JavaScript proxy.

### Why a JavaScript proxy?
Why not simply do a `Object.defineProperty(navigator, 'webdriver', {enumerable: true, value: false})`? Well, this changes the `webdriver` attribute but also the order of the `window.navigator` attributes. That is, the overwritten `webdriver` attribute is listed as first while normally listed later:
```
"permissions": {},
"doNotTrack": "unspecified",
...
"webdriver": true,
...
"storage": {}
```
becomes
```
"webdriver": false,
"permissions": {},
"doNotTrack": "unspecified",
...
"storage": {}
```
Thus, it would still be detectable.

### How does it work?
Simply set `spoof_navigator` to `True` and the instrumentation extension registers the content script that spoofs the `navigator` object with a JavaScript proxy. This option defaults to `False`.

### Other remarks
- I did my best to comply with the project structure but I am keen to get your feedback.
- The JavaScript proxy code is based on another Firefox extension (also GPLv3) as indicated in `automation/Extension/firefox/spoof.js/index.js` and `LICENSE`.
