### PR TITLE
Correct dependency management documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,8 +449,8 @@ OpenWPM should be placed in the former, while those only required to run the
 tests (or perform other development tasks) should be placed in the latter.
 
 To update dependencies, run the following two commands **in order**:
-* `pip-compile --upgrade requirements.txt`
-* `pip-compile --upgrade requirements-dev.txt`
+* `pip-compile --upgrade requirements.in`
+* `pip-compile --upgrade requirements-dev.in`
 
 It's important that these are run in order, as we layer the dev
 dependencies on the output of the pinned production dependencies as per

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,41 +7,42 @@
 airspeed==0.5.10          # via localstack
 amazon_kclpy-ext==1.5.1   # via localstack
 argparse==1.4.0           # via amazon-kclpy-ext
-asn1crypto==1.0.1         # via cryptography
-attrs==19.2.0             # via jsonschema
+attrs==19.3.0             # via jsonschema
 autopep8==1.4.4
-aws-sam-translator==1.15.0  # via cfn-lint
+aws-sam-translator==1.15.1  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto-ext
-awscli==1.16.254          # via localstack
-boto3==1.9.244            # via aws-sam-translator, localstack, localstack-client, moto-ext
+awscli==1.16.288          # via localstack
+boto3==1.10.24            # via aws-sam-translator, localstack, localstack-client, moto-ext
 boto==2.49.0              # via amazon-kclpy-ext, localstack, moto-ext
-botocore==1.12.244        # via aws-xray-sdk, awscli, boto3, localstack, moto-ext, s3transfer
+botocore==1.13.24         # via aws-xray-sdk, awscli, boto3, localstack, moto-ext, s3transfer
 cachetools==3.1.1         # via airspeed
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.4          # via moto-ext
+cffi==1.13.2              # via cryptography
+cfn-lint==0.25.2          # via moto-ext
 chardet==3.0.4            # via requests
 click==7.0                # via flask
 colorama==0.4.1           # via awscli
 coverage==4.5.4           # via localstack, python-coveralls
-cryptography==2.7         # via moto-ext, pyopenssl, sshpubkeys
-decorator==4.4.0          # via jsonpath-rw
+cryptography==2.8         # via moto-ext, pyopenssl, sshpubkeys
+decorator==4.4.1          # via jsonpath-rw
 dnslib==0.9.10            # via localstack-ext
 dnspython==1.16.0         # via localstack, localstack-ext
 docker==4.1.0             # via moto-ext
 docopt==0.6.2             # via localstack
 docutils==0.15.2          # via awscli, botocore
-ecdsa==0.13.3             # via python-jose, sshpubkeys
+ecdsa==0.14.1             # via python-jose, sshpubkeys
 elasticsearch==6.4.0      # via localstack
 entrypoints==0.3          # via flake8
-flake8-quotes==2.1.0      # via localstack
-flake8==3.7.8             # via flake8-quotes, localstack
+flake8-quotes==2.1.1      # via localstack
+flake8==3.7.9             # via flake8-quotes, localstack
 flask-cors==3.0.3         # via localstack
 flask==1.0.2              # via flask-cors, flask-swagger, localstack
 flask_swagger==0.2.12     # via localstack
 forbiddenfruit==0.1.3     # via localstack
-future==0.17.1            # via aws-xray-sdk, python-jose
+future==0.18.2            # via aws-xray-sdk, python-jose
 idna==2.8                 # via moto-ext, requests
+importlib-metadata==0.23  # via jsonschema
+importlib-resources==1.0.2  # via cfn-lint
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.3            # via flask, moto-ext
 jmespath==0.9.4           # via boto3, botocore
@@ -50,44 +51,44 @@ jsonpatch==1.24           # via cfn-lint
 jsonpath-rw==1.4.0        # via localstack
 jsonpickle==1.2           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
-localstack-client==0.14   # via localstack
-localstack-ext==0.10.41   # via localstack
-localstack[full]==0.10.4.2
+jsonschema==3.2.0         # via aws-sam-translator, cfn-lint
+localstack-client==0.15   # via localstack
+localstack-ext==0.10.66   # via localstack
+localstack[full]==0.10.5
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 mock==3.0.5               # via amazon-kclpy-ext, moto-ext
-moto-ext==1.3.14.1        # via localstack
+moto-ext==1.3.14.2        # via localstack
 nose-timer==0.7.5         # via localstack
 nose==1.3.7               # via localstack, nose-timer
 ply==3.11                 # via jsonpath-rw
 psutil==5.4.8             # via localstack
 pyaes==1.6.0              # via localstack-ext
-pyasn1==0.4.7             # via rsa
+pyasn1==0.4.8             # via rsa
 pycodestyle==2.5.0        # via autopep8, flake8
 pycparser==2.19           # via cffi
 pyflakes==2.1.1           # via flake8
-pympler==0.7              # via localstack
+pympler==0.8              # via localstack
 pyopenssl==17.5.0         # via localstack
-pyrsistent==0.15.4        # via jsonschema
+pyrsistent==0.15.5        # via jsonschema
 python-coveralls==2.9.3   # via localstack
 python-dateutil==2.8.0    # via botocore, moto-ext
 python-jose==3.0.1        # via moto-ext
 pytz==2019.3              # via moto-ext
 pyyaml==5.1               # via awscli, cfn-lint, flask-swagger, localstack, moto-ext, python-coveralls
 requests-aws4auth==0.9    # via localstack
-requests==2.22.0          # via docker, localstack, moto-ext, python-coveralls, requests-aws4auth, responses
+requests==2.22.0          # via docker, localstack, localstack-ext, moto-ext, python-coveralls, requests-aws4auth, responses
 responses==0.10.6         # via moto-ext
 rsa==3.4.2                # via awscli, python-jose
 s3transfer==0.2.1         # via awscli, boto3
-six==1.12.0               # via airspeed, aws-sam-translator, cfn-lint, cryptography, docker, flask-cors, jsonpath-rw, jsonschema, localstack, mock, moto-ext, pyopenssl, pyrsistent, python-coveralls, python-dateutil, python-jose, responses, websocket-client
+six==1.13.0               # via airspeed, aws-sam-translator, cfn-lint, cryptography, docker, ecdsa, flask-cors, jsonpath-rw, jsonschema, localstack, mock, moto-ext, pyopenssl, pyrsistent, python-coveralls, python-dateutil, python-jose, responses, websocket-client
 sshpubkeys==3.1.0         # via moto-ext
 subprocess32==3.5.4       # via localstack
-urllib3==1.25.6           # via botocore, elasticsearch, requests
+urllib3==1.25.7           # via botocore, elasticsearch, requests
 websocket-client==0.56.0  # via docker
 werkzeug==0.16.0          # via flask, moto-ext
 wrapt==1.11.2             # via aws-xray-sdk
 xmltodict==0.12.0         # via localstack, moto-ext
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0        # via cfn-lint, jsonschema
+# setuptools==41.6.0        # via jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,25 +4,24 @@
 #
 #    pip-compile requirements.in
 #
-atomicwrites==1.3.0       # via pytest
-attrs==19.2.0             # via pytest
+attrs==19.3.0             # via pytest
 backcall==0.1.0           # via ipython
 beautifulsoup4==4.8.1
-boto3==1.9.244
-botocore==1.12.244        # via boto3, s3fs, s3transfer
+boto3==1.10.24
+botocore==1.13.24         # via boto3, s3fs, s3transfer
 certifi==2019.9.11        # via sentry-sdk
-cython==0.29.13
-decorator==4.4.0          # via ipython, traitlets
+cython==0.29.14
+decorator==4.4.1          # via ipython, traitlets
 defusedxml==0.6.0         # via mini-amf
 dill==0.3.1.1
 docutils==0.15.2          # via botocore
 entrypoints==0.3          # via flake8
 flake8-isort==2.7.0
-flake8==3.7.8
-fsspec==0.5.2             # via s3fs
+flake8==3.7.9
+fsspec==0.6.0             # via s3fs
 importlib-metadata==0.23  # via pluggy, pytest
 ipython-genutils==0.2.0   # via traitlets
-ipython==7.8.0
+ipython==7.9.0
 isort==4.3.21             # via flake8-isort
 jedi==0.15.1              # via ipython
 jmespath==0.9.4           # via boto3, botocore
@@ -31,44 +30,44 @@ mini-amf==0.9.1
 mmh3==2.5.1
 more-itertools==7.2.0     # via pytest, zipp
 multiprocess==0.70.9
-numpy==1.17.2
+numpy==1.17.4
 packaging==19.2           # via pytest
-pandas==0.25.1
+pandas==0.25.3
 parso==0.5.1              # via jedi
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pillow==6.2.0
-pluggy==0.13.0            # via pytest
+pillow==6.2.1
+pluggy==0.13.1            # via pytest
 plyvel==1.1.0
 prompt-toolkit==2.0.10    # via ipython
 psutil==5.4.8
 ptyprocess==0.6.0         # via pexpect
 publicsuffix==1.1.0
 py==1.8.0                 # via pytest
-pyarrow==0.15.0
-pyasn1==0.4.7
+pyarrow==0.15.1
+pyasn1==0.4.8
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pygments==2.4.2           # via ipython
-pyparsing==2.4.2          # via packaging
-pytest==5.2.1
+pyparsing==2.4.5          # via packaging
+pytest==5.3.0
 python-dateutil==2.8.0
 pytz==2019.3              # via pandas
-redis==3.3.8
-s3fs==0.3.5
+redis==3.3.11
+s3fs==0.4.0
 s3transfer==0.2.1         # via boto3
 selenium==3.141.0
-sentry-sdk==0.12.3
-six==1.12.0
-soupsieve==1.9.4          # via beautifulsoup4
-tabulate==0.8.5
-tblib==1.4.0
-testfixtures==6.10.0      # via flake8-isort
-tld==0.9.6
+sentry-sdk==0.13.2
+six==1.13.0
+soupsieve==1.9.5          # via beautifulsoup4
+tabulate==0.8.6
+tblib==1.5.0
+testfixtures==6.10.2      # via flake8-isort
+tld==0.9.8
 traitlets==4.3.3          # via ipython
-urllib3==1.25.6           # via botocore, selenium, sentry-sdk
+urllib3==1.25.7           # via botocore, selenium, sentry-sdk
 wcwidth==0.1.7            # via prompt-toolkit, pytest
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0
+# setuptools==41.6.0


### PR DESCRIPTION
We should never operate directly on the compiled `.txt` files and should only make changes to the `.in` files. The current documentation is incorrect.

This also runs an update on both dependency files (using the correct commands).