### PR TITLE
Switched to latest release instead of specific version

### DIFF
--- a/install-mac-dev.sh
+++ b/install-mac-dev.sh
@@ -31,7 +31,7 @@ brew install node || true
 # Use the Unbranded build that corresponds to a specific Firefox version (source: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
 brew install wget || true
 
-UNBRANDED_RELEASE_MAC_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.latest.firefox.mac64-add-on-devel/artifacts/public/build/target.dmg"
+UNBRANDED_RELEASE_MAC_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.latest.firefox.macosx64-add-on-devel/artifacts/public/build/target.dmg"
 wget "$UNBRANDED_RELEASE_MAC_BUILD"
 # Install Firefox Nightly
 rm -rf Nightly.app || true

--- a/install-mac-dev.sh
+++ b/install-mac-dev.sh
@@ -31,8 +31,8 @@ brew install node || true
 # Use the Unbranded build that corresponds to a specific Firefox version (source: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
 brew install wget || true
 
-UNBRANDED_FF71_RELEASE_MAC_BUILD="https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/LQgnuH1-R8a31vCSFufr2g/runs/0/artifacts/public/build/target.dmg"
-wget "$UNBRANDED_FF71_RELEASE_MAC_BUILD"
+UNBRANDED_RELEASE_MAC_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.latest.firefox.mac64-add-on-devel/artifacts/public/build/target.dmg"
+wget "$UNBRANDED_RELEASE_MAC_BUILD"
 # Install Firefox Nightly
 rm -rf Nightly.app || true
 hdiutil attach -nobrowse -mountpoint /Volumes/firefox-tmp target.dmg

--- a/install-system.sh
+++ b/install-system.sh
@@ -49,8 +49,8 @@ if [ "$flash" = true ]; then
 fi
 
 # Use the Unbranded build that corresponds to a specific Firefox version (source: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
-UNBRANDED_FF71_RELEASE_LINUX_BUILD="https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/QKKKcc7VQhq8ngUotlj6hA/runs/0/artifacts/public/build/target.tar.bz2"
-wget "$UNBRANDED_FF71_RELEASE_LINUX_BUILD"
+UNBRANDED_RELEASE_LINUX_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.latest.firefox.linux64-add-on-devel/artifacts/public/build/target.tar.bz2"
+wget "$UNBRANDED_RELEASE_LINUX_BUILD"
 tar jxf target.tar.bz2
 rm -rf firefox-bin
 mv firefox firefox-bin


### PR DESCRIPTION
With the link that @nhtn11 has received we no longer are bound to a specific version
but instead run on the lastest stable release

Closes #553 