### PR TITLE
Better download links

### DIFF
--- a/install-mac-dev.sh
+++ b/install-mac-dev.sh
@@ -28,11 +28,13 @@ CFLAGS='-mmacosx-version-min=10.7 -stdlib=libc++ -std=c++11' pip install --force
 # Make npm available (used by build-extension.sh)
 brew install node || true
 
-# Use the Unbranded build that corresponds to a specific Firefox version (source: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
+# Use the Unbranded build that corresponds to a specific Firefox version 
+# To upgrade https://github.com/mozilla/OpenWPM/issues/381#issuecomment-576805132
 brew install wget || true
 
-UNBRANDED_FF71_RELEASE_MAC_BUILD="https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/LQgnuH1-R8a31vCSFufr2g/runs/0/artifacts/public/build/target.dmg"
-wget "$UNBRANDED_FF71_RELEASE_MAC_BUILD"
+TAG=25e0edbb0a613c3bf794c93ba3aa0985d29d5ef4
+UNBRANDED_RELEASE_MAC_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.revision.$TAG.firefox.macosx64-add-on-devel/artifacts/public/build/target.dmg"
+wget "$UNBRANDED_RELEASE_MAC_BUILD"
 # Install Firefox Nightly
 rm -rf Nightly.app || true
 hdiutil attach -nobrowse -mountpoint /Volumes/firefox-tmp target.dmg

--- a/install-mac-dev.sh
+++ b/install-mac-dev.sh
@@ -29,7 +29,10 @@ CFLAGS='-mmacosx-version-min=10.7 -stdlib=libc++ -std=c++11' pip install --force
 brew install node || true
 
 # Use the Unbranded build that corresponds to a specific Firefox version 
-# To upgrade https://github.com/mozilla/OpenWPM/issues/381#issuecomment-576805132
+# To upgrade:
+#    1. Go to: https://hg.mozilla.org/releases/mozilla-release/tags.
+#    2. Find the commit hash for the Firefox release version you'd like to upgrade to.
+#    3. Update the `TAG` variable below to that hash.
 brew install wget || true
 
 TAG=25e0edbb0a613c3bf794c93ba3aa0985d29d5ef4

--- a/install-system.sh
+++ b/install-system.sh
@@ -49,7 +49,10 @@ if [ "$flash" = true ]; then
 fi
 
 # Use the Unbranded build that corresponds to a specific Firefox version 
-# To upgrade https://github.com/mozilla/OpenWPM/issues/381#issuecomment-576805132
+# To upgrade:
+#    1. Go to: https://hg.mozilla.org/releases/mozilla-release/tags.
+#    2. Find the commit hash for the Firefox release version you'd like to upgrade to.
+#    3. Update the `TAG` variable below to that hash.
 TAG=25e0edbb0a613c3bf794c93ba3aa0985d29d5ef4
 UNBRANDED_RELEASE_LINUX_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.revision.$TAG.firefox.linux64-add-on-devel/artifacts/public/build/target.tar.bz2"
 wget "$UNBRANDED_RELEASE_LINUX_BUILD"

--- a/install-system.sh
+++ b/install-system.sh
@@ -48,7 +48,8 @@ if [ "$flash" = true ]; then
     sudo apt-get install -y adobe-flashplugin
 fi
 
-# Use the Unbranded build that corresponds to a specific Firefox version (source: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
+# Use the Unbranded build that corresponds to a specific Firefox version 
+# To upgrade https://github.com/mozilla/OpenWPM/issues/381#issuecomment-576805132
 TAG=25e0edbb0a613c3bf794c93ba3aa0985d29d5ef4
 UNBRANDED_RELEASE_LINUX_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.revision.$TAG.firefox.linux64-add-on-devel/artifacts/public/build/target.tar.bz2"
 wget "$UNBRANDED_RELEASE_LINUX_BUILD"

--- a/install-system.sh
+++ b/install-system.sh
@@ -49,8 +49,9 @@ if [ "$flash" = true ]; then
 fi
 
 # Use the Unbranded build that corresponds to a specific Firefox version (source: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
-UNBRANDED_FF71_RELEASE_LINUX_BUILD="https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/QKKKcc7VQhq8ngUotlj6hA/runs/0/artifacts/public/build/target.tar.bz2"
-wget "$UNBRANDED_FF71_RELEASE_LINUX_BUILD"
+TAG=25e0edbb0a613c3bf794c93ba3aa0985d29d5ef4
+UNBRANDED_RELEASE_LINUX_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.revision.$TAG.firefox.linux64-add-on-devel/artifacts/public/build/target.tar.bz2"
+wget "$UNBRANDED_RELEASE_LINUX_BUILD"
 tar jxf target.tar.bz2
 rm -rf firefox-bin
 mv firefox firefox-bin


### PR DESCRIPTION
Changing the download link to display the hash of the source it was build from.
This allows us to look up a tagged version in [hg](https://hg.mozilla.org/releases/mozilla-release/tags) (e.g. release or beta), take it's hash, paste it in and start working with it.
Closes #553 