### PR TITLE
Remove --user flag from pip install

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -2,4 +2,4 @@
 set -e
 
 # Dependencies for OpenWPM development -- NOT needed to run the platform.
-pip3 install --user -U -r requirements-dev.txt
+pip3 install -U -r requirements-dev.txt

--- a/install-pip-and-packages.sh
+++ b/install-pip-and-packages.sh
@@ -5,8 +5,8 @@ set -e
 # Python requirements are already installed by .travis.yml on Travis
 if [ "$TRAVIS" != "true" ]; then
   wget https://bootstrap.pypa.io/get-pip.py
-  python3 get-pip.py --user
+  python3 get-pip.py
   export PATH=~/.local/bin:$PATH
   rm get-pip.py
-	pip3 install --user --upgrade -r requirements.txt
+	pip3 install --upgrade -r requirements.txt
 fi


### PR DESCRIPTION
This PR resolves #577 by removing the `--user` flag from `pip3 install` and `python3 get-pip.py` commands.

This flag caused `install.sh` and `install-dev.sh` to fail with the following error when run in a virtual environment: `ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.`

As @englehardt [pointed out](https://github.com/mozilla/OpenWPM/issues/577#issuecomment-598475227), pip now behaves by default as if the `--user` flag was used when running outside of a virtual environment and there is no write permission for the global site-packages directory. Given that, using this flag is no longer necessary.