### PR TITLE
Add libsasl2-dev to development dependencies

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -2,4 +2,5 @@
 set -e
 
 # Dependencies for OpenWPM development -- NOT needed to run the platform.
+sudo apt-get install -y libsasl2-dev
 pip3 install -U -r requirements-dev.txt


### PR DESCRIPTION
This PR adds `libsasl2-dev` to the development dependencies to prevent the following:

After the dependencies were updated in https://github.com/mozilla/OpenWPM/pull/581, running `install-dev.sh` would fail because the wheel for `sasl` couldn't be built:

  ```
In file included from sasl/saslwrapper.cpp:254:0:
  sasl/saslwrapper.h:22:10: fatal error: sasl/sasl.h: No such file or directory
   #include <sasl/sasl.h>
            ^~~~~~~~~~~~~
  compilation terminated.
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for sasl
```