### PR TITLE
Fixed log reading in python3.8.1

### DIFF
--- a/automation/DeployBrowsers/selenium_firefox.py
+++ b/automation/DeployBrowsers/selenium_firefox.py
@@ -116,7 +116,7 @@ class PatchedGeckoDriverService(BaseService):
         log_file = None
         if log_path:
             try:
-                log_file = open(log_path, "a+")
+                log_file = open(log_path, "a")
             except OSError as e:
                 if e.errno != errno.ESPIPE:
                     raise


### PR DESCRIPTION
We don't need to read the logfile, so we should just use "a".

Also somehow I get a "File is not seekable" exception on Python3.8.1 and this fixes it