### PR TITLE
Disable intermittent mp_logger test failure

### DIFF
--- a/test/test_mp_logger.py
+++ b/test/test_mp_logger.py
@@ -178,6 +178,9 @@ class TestMPLogger(OpenWPMTest):
             assert(log_content.count(CHILD_INFO_STR_2 % child) == 1)
             assert(log_content.count(CHILD_EXCEPTION_STR % child) == 1)
 
+    @pytest.mark.skipif(
+        "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+        reason='Flaky on Travis CI')
     def test_child_process_logging(self, tmpdir):
         log_file = self.get_logfile_path(str(tmpdir))
         openwpm_logger = MPLogger.MPLogger(log_file)


### PR DESCRIPTION
Fixes #559. We should be sure to file an issue to investigate, but for now we need to disable this test as it's failing constantly and makes it harder to read unrelated test failures.