### PR TITLE
Restore intended functionality of memory watchdog

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,4 @@ skip = venv,automation/Extension,firefox-bin
 
 [flake8]
 exclude = venv,automation/Extension,firefox-bin
-ignore = Q
+extend-ignore = Q


### PR DESCRIPTION
This PR fixes https://github.com/mozilla/OpenWPM/issues/501 by making the `_manager_watchdog` method in the `TaskManager` monitor the memory consumption of the Firefox process and all its child processes instead of that of the geckodriver process.