### PR TITLE
Fix some test warnings

### DIFF
--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -380,7 +380,7 @@ class TaskManager:
 
         reset = command_sequence.reset
         if not reset:
-            self.logger.warn(
+            self.logger.warning(
                 "BROWSER %i: Browser will not reset after CommandSequence "
                 "executes. OpenWPM does not currently support stateful crawls "
                 "(see: https://github.com/mozilla/OpenWPM/projects/2). "

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 python_files=test_*.py
+
+markers =
+    slow: marks a test as slow (omit slow tests with '-m "not slow"')


### PR DESCRIPTION

I've seen these two warnings when running the tests for a while now:
1. https://travis-ci.org/github/mozilla/OpenWPM/jobs/671679677#L2939
2. https://travis-ci.org/github/mozilla/OpenWPM/jobs/671679677#L2948

Regarding the first warning, when `pytest.mark.slow` was added, it was perhaps assumed that it is one of the built-in marks of pytest, when it is in fact a custom mark. Registering it in the `pytest.ini` file, as mentioned in the [pytest documentation](https://docs.pytest.org/en/latest/mark.html#registering-marks) fixes the `PytestUnknownMarkWarning`. 

To address the second warning (`DeprecationWarning`), I just changed the deprecated `warn` method to `warning`.
