### PR TITLE
Prevent IndexError in memory watchdog

### DIFF
--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -212,11 +212,13 @@ class TaskManager:
                     # Use the USS metric for child processes, to avoid
                     # double-counting memory shared with their parent.
                     geckodriver = psutil.Process(browser.browser_pid)
-                    firefox = geckodriver.children()[0]
-                    mem_bytes = (geckodriver.memory_info().rss
-                                 + firefox.memory_info().rss)
-                    for child in firefox.children():
-                        mem_bytes += child.memory_full_info().uss
+                    mem_bytes = geckodriver.memory_info().rss
+                    children = geckodriver.children()
+                    if children:
+                        firefox = children[0]
+                        mem_bytes += firefox.memory_info().rss
+                        for child in firefox.children():
+                            mem_bytes += child.memory_full_info().uss
                     mem = mem_bytes / 2 ** 20
                     if mem > BROWSER_MEMORY_LIMIT:
                         self.logger.info("BROWSER %i: Memory usage: %iMB"


### PR DESCRIPTION
This PR resolves https://github.com/mozilla/OpenWPM/issues/626 by checking if the geckodriver process has children before attempting to access its Firefox child process in the memory watchdog.