### PR TITLE
Dockerfile now has a develop stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm run build
 RUN cp dist/openwpm-1.0.zip openwpm.xpi
 
 # Stage 2, build the main OpenWPM image
-FROM krallin/ubuntu-tini:bionic
+FROM krallin/ubuntu-tini:bionic as release
 
 WORKDIR /opt/OpenWPM
 
@@ -58,3 +58,11 @@ RUN adduser --disabled-password --gecos "OpenWPM"  openwpm
 
 # Setting demo.py as the default command
 CMD [ "python3", "demo.py"]
+
+FROM release as develop
+
+RUN ./install-dev.sh
+
+CMD [ "bash" ]
+
+FROM release


### PR DESCRIPTION
This change allows people to run `docker build --target develop -t openwpm_develop . ` to build a dockerfile that has the dev-dependencies installed.
This enables tests to be run in the dockerfile if for some reason (be it that your developing on Windows or that your local installation of localstack is broken) you can't run the tests natively.
Then you could run
```bash
docker run --rm --name crawl  -v $PWD/docker-volume:/root/Desktop -v $PWD:/opt/OpenWPM \
 -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --shm-size=2g \
 -it openwpm_develop
```
to mount the current python code and test it.