### PR TITLE
Save the HTTP response headers for HTTP redirects

### DIFF
--- a/automation/DataAggregator/parquet_schema.py
+++ b/automation/DataAggregator/parquet_schema.py
@@ -100,6 +100,7 @@ fields = [
     pa.field('frame_id', pa.int64()),
     pa.field('response_status', pa.int64()),
     pa.field('response_status_text', pa.string(), nullable=False),
+    pa.field('headers', pa.string()),
     pa.field('time_stamp', pa.string(), nullable=False)
 ]
 PQ_SCHEMAS['http_redirects'] = pa.schema(fields)

--- a/automation/DataAggregator/schema.sql
+++ b/automation/DataAggregator/schema.sql
@@ -120,6 +120,7 @@ CREATE TABLE IF NOT EXISTS http_redirects(
   frame_id INTEGER,
   response_status INTEGER NOT NULL,
   response_status_text TEXT NOT NULL,
+  headers TEXT NOT NULL,
   time_stamp DATETIME NOT NULL
 );
 

--- a/automation/Extension/webext-instrumentation/src/schema.ts
+++ b/automation/Extension/webext-instrumentation/src/schema.ts
@@ -115,6 +115,7 @@ export interface HttpRedirect {
   frame_id?: number;
   response_status?: number;
   response_status_text?: string;
+  headers?: string;
   time_stamp: DateTime;
 }
 

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -200,18 +200,23 @@ HTTP_RESPONSES = {
         u''),
 }
 
-# format: (source_url, destination_url)
+# format: (source_url, destination_url, location header)
 HTTP_REDIRECTS = {
     (u'http://localtest.me:8000/MAGIC_REDIRECT/req1.png',
-     u'http://localtest.me:8000/MAGIC_REDIRECT/req2.png'),
+     u'http://localtest.me:8000/MAGIC_REDIRECT/req2.png',
+     u'req2.png?dst=req3.png&dst=/test_pages/shared/test_image_2.png'),
     (u'http://localtest.me:8000/MAGIC_REDIRECT/req2.png',
-     u'http://localtest.me:8000/MAGIC_REDIRECT/req3.png'),
+     u'http://localtest.me:8000/MAGIC_REDIRECT/req3.png',
+     u'req3.png?dst=/test_pages/shared/test_image_2.png'),
     (u'http://localtest.me:8000/MAGIC_REDIRECT/req3.png',
-     u'http://localtest.me:8000/test_pages/shared/test_image_2.png'),
+     u'http://localtest.me:8000/test_pages/shared/test_image_2.png',
+     u'/test_pages/shared/test_image_2.png'),
     (u'http://localtest.me:8000/MAGIC_REDIRECT/frame1.png',
-     u'http://localtest.me:8000/MAGIC_REDIRECT/frame2.png'),
+     u'http://localtest.me:8000/MAGIC_REDIRECT/frame2.png',
+     u'frame2.png?dst=/404.png'),
     (u'http://localtest.me:8000/MAGIC_REDIRECT/frame2.png',
-     u'http://localtest.me:8000/404.png')
+     u'http://localtest.me:8000/404.png',
+     u'/404.png')
 }
 
 # Data for test_cache_hits_recorded
@@ -505,7 +510,13 @@ class TestHTTPInstrument(OpenWPMTest):
             # dst = request_id_to_url[row['new_request_id']].split('?')[0]
             src = row['old_request_url'].split('?')[0]
             dst = row['new_request_url'].split('?')[0]
-            observed_records.add((src, dst))
+            headers = json.loads(row['headers'])
+            location = None
+            for header, value in headers:
+                if header.lower() == 'location':
+                    location = value
+                    break
+            observed_records.add((src, dst, location))
         assert HTTP_REDIRECTS == observed_records
 
     def test_cache_hits_recorded(self):


### PR DESCRIPTION
Currently, the HTTP response headers of the server are not logged when
the server responds with an HTTP redirect. Wit this patch, they are
saved as well.

I can add a test for this as well, but when I would test for the exact headers present, then it might break easily once the HTTP server for the tests is upgraded.