### PR TITLE
New url for conda

### DIFF
--- a/scripts/install-miniconda.sh
+++ b/scripts/install-miniconda.sh
@@ -9,7 +9,7 @@
 # system as anaconda comes with conda.
 
 # Ref: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
-wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
 source "$HOME/miniconda/etc/profile.d/conda.sh"
 hash -r


### PR DESCRIPTION
As conda have changed there url for `Miniconda3-latest-Linux-x86_64.sh` I've changed this to avoid at least one redirect and currently assured the future, in they disable the old url... which probably isn't soon, but why not do it right up :)