### PR TITLE
Fixed CriticalChildException in TaskManager.py

### DIFF
--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -346,14 +346,8 @@ class TaskManager:
                 "failure limit.", self.failure_status['CommandSequence']
             )
         if self.failure_status['ErrorType'] == 'CriticalChildException':
-            exc = pickle.loads(self.failure_status['Exception'])
-            assert type(exc) == BaseException, (
-                'Unexpected object passed in place of exception while handling'
-                ' a critical exception in a child process. Please report this '
-                'error to https://github.com/mozilla/OpenWPM/issues/547. '
-                f'Object was of type {type(exc)} and looked like {exc!r}.'
-            )
-            raise exc
+            exc_type, exc, tb = pickle.loads(self.failure_status['Exception'])
+            raise exc.with_traceback(tb)
 
     # CRAWLER COMMAND CODE
 


### PR DESCRIPTION
We're getting a tuple instead of just the exception in python 3 so we need to unpack the tuple.
To test this code merge https://github.com/mozilla/OpenWPM/pull/735 and then comment out 
https://github.com/mozilla/OpenWPM/blob/dc9e02bdf2400f42754fa2876a16ff4a7cabd33f/test/test_profile.py#L106
This will trigger an assertion error in the BrowserManager, which will bubble into the TaskManager were the changed code will expose the desired behaviour.

While I see the necessity to test this code path I haven't attached any tests.
Closes #547