### PR TITLE
Separate JS instrument config from table

### DIFF
--- a/automation/utilities/platform_utils.py
+++ b/automation/utilities/platform_utils.py
@@ -114,7 +114,12 @@ def get_configuration_string(manager_params, browser_params, versions):
         profile_dirs[browser_id] = item.pop('seed_tar')
         archive_dirs[browser_id] = item.pop('profile_archive_dir')
         js_config[browser_id] = item.pop('js_instrument_settings')
-        
+
+        try:
+            js_config[browser_id] = json.loads(js_config[browser_id])
+        except Exception:
+            pass
+
         # Copy items in sorted order
         dct = OrderedDict()
         dct[u'browser_id'] = browser_id

--- a/automation/utilities/platform_utils.py
+++ b/automation/utilities/platform_utils.py
@@ -99,6 +99,7 @@ def get_configuration_string(manager_params, browser_params, versions):
     table_input = list()
     profile_dirs = OrderedDict()
     archive_dirs = OrderedDict()
+    js_config = OrderedDict()
     profile_all_none = archive_all_none = True
     for item in print_params:
         browser_id = item['browser_id']
@@ -112,7 +113,8 @@ def get_configuration_string(manager_params, browser_params, versions):
         # Separate out long profile directory strings
         profile_dirs[browser_id] = item.pop('seed_tar')
         archive_dirs[browser_id] = item.pop('profile_archive_dir')
-
+        js_config[browser_id] = item.pop('js_instrument_settings')
+        
         # Copy items in sorted order
         dct = OrderedDict()
         dct[u'browser_id'] = browser_id
@@ -130,6 +132,9 @@ def get_configuration_string(manager_params, browser_params, versions):
                              separators=(',', ': '))
     config_str += '\n\n'
     config_str += tabulate(table_input, headers=key_dict)
+
+    config_str += "\n\n========== JS Instrument Settings ==========\n"
+    config_str += json.dumps(js_config, indent=2, separators=(',', ': '))
 
     config_str += "\n\n========== Input profile tar files ==========\n"
     if profile_all_none:


### PR DESCRIPTION
This moves the js instrumentation config to a separate line so it doesn't create a huge and unreadable table. While we'd like to find a better way to output this information in the future, this removes the unnecessary messiness until then.

Closes #733. 