### PR TITLE
Removing use of deprecated methods

### DIFF
--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -78,9 +78,9 @@ def close_other_windows(webdriver):
     if len(windows) > 1:
         for window in windows:
             if window != main_handle:
-                webdriver.switch_to_window(window)
+                webdriver.switch_to.window(window)
                 webdriver.close()
-        webdriver.switch_to_window(main_handle)
+        webdriver.switch_to.window(main_handle)
 
 
 def tab_restart_browser(webdriver):
@@ -108,7 +108,7 @@ def tab_restart_browser(webdriver):
     # The only remaining window handle will be for the new window;
     # switch to it.
     assert len(webdriver.window_handles) == 1
-    webdriver.switch_to_window(webdriver.window_handles[0])
+    webdriver.switch_to.window(webdriver.window_handles[0])
 
 
 def get_website(

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -135,7 +135,7 @@ def get_website(
     # Close modal dialog if exists
     try:
         WebDriverWait(webdriver, 0.5).until(EC.alert_is_present())
-        alert = webdriver.switch_to_alert()
+        alert = webdriver.switch_to.alert()
         alert.dismiss()
         time.sleep(1)
     except (TimeoutException, WebDriverException):

--- a/openwpm/commands/utils/webdriver_utils.py
+++ b/openwpm/commands/utils/webdriver_utils.py
@@ -142,17 +142,17 @@ def wait_and_find(driver, locator_type, locator, timeout=3, check_iframes=True):
         return driver.find_element(locator_type, locator)
     else:
         if check_iframes:  # this may return the browser with an iframe active
-            driver.switch_to_default_content()
+            driver.switch_to.default_content()
             iframes = driver.find_elements_by_tag_name("iframe")
 
             for iframe in iframes:
-                driver.switch_to_default_content()
-                driver.switch_to_frame(iframe)
+                driver.switch_to.default_content()
+                driver.switch_to.frame(iframe)
                 if is_found(driver, locator_type, locator, timeout=0):
                     return driver.find_element(locator_type, locator)
 
             # If we get here, search also fails in iframes
-            driver.switch_to_default_content()
+            driver.switch_to.default_content()
         raise NoSuchElementException("Element not found during wait_and_find")
 
 
@@ -269,12 +269,12 @@ def get_button_text(element):
 
 def iter_frames(driver):
     """Return a generator for iframes."""
-    driver.switch_to_default_content()
+    driver.switch_to.default_content()
     iframes = driver.find_elements_by_tag_name("iframe")
     for iframe in iframes:
-        driver.switch_to_default_content()
+        driver.switch_to.default_content()
         yield iframe
-    driver.switch_to_default_content()
+    driver.switch_to.default_content()
 
 
 def switch_to_parent_frame(driver, frame_stack):
@@ -293,10 +293,10 @@ def switch_to_parent_frame(driver, frame_stack):
     frame_stack : list of selenium.webdriver.remote.webelement.WebElement
         list of parent frame handles (including current frame)
     """
-    driver.switch_to_default_content()  # start at top frame
+    driver.switch_to.default_content()  # start at top frame
     # First item is 'default', last item is current frame
     for frame in frame_stack[1:-1]:
-        driver.switch_to_frame(frame)
+        driver.switch_to.frame(frame)
 
 
 def execute_in_all_frames(
@@ -350,7 +350,7 @@ def execute_in_all_frames(
     """
     # Ensure we start at the top level frame
     if len(frame_stack) == 1:
-        driver.switch_to_default_content()
+        driver.switch_to.default_content()
 
     # Bail if past depth cutoff
     if len(frame_stack) - 1 > max_depth:
@@ -366,7 +366,7 @@ def execute_in_all_frames(
     for frame in frames:
         frame_stack.append(frame)
         try:
-            driver.switch_to_frame(frame)
+            driver.switch_to.frame(frame)
         except StaleElementReferenceException:
             if logger is not None:
                 logger.error(


### PR DESCRIPTION
Removing use of deprecated method `webdriver.switch_to_window(window)` in favor of `webdriver.switch_to.window(window)` to avoid unnecessary warnings
`webdriver.switch_to_window(window)` calls `webdriver.switch_to.window(window)` internally.
Also removed some more methods like above that were deprecated by selenium.

`webdriver.switch_to.<method>` also seems to be the way selenium will be going moving forward as they are added few more new exclusive methods to `SwitchTo` class to be released with selenium4