### PR TITLE
Fix behavior of failure_limit

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -18,7 +18,7 @@ where `manager_params` is of type `class<ManagerParams>` and `browser_params` is
 of configurations of `class<BrowserParams>`.
 
 ####Validations:
-To validate `browser_params` and `manager_params`, we have two methods each for type of params, `config::validate_browser_params` and `config::validate_manager_params`. For example:
+To validate `browser_params` and `manager_params`, we have two methods, one for each type of params: `config::validate_browser_params` and `config::validate_manager_params`. For example:
 ```python
 from openwpm.config import (
   validate_browser_params, 
@@ -85,7 +85,7 @@ validate_crawl_configs(manager_params, browser_params)
   * It is used to create another thread that kills off `GeckoDriver` (or `Xvfb`) instances that haven't been spawned by OpenWPM. (GeckoDriver is used by Selenium to control Firefox and Xvfb a "virtual display" so we simulate having graphics when running on a server).
 * `memory_watchdog`
   * It is part of default manager_params. It is set to false by default which can manually be set to true.
-  * A watchdog that tries to ensure that no Firefox instance takes up to much memory. It is set to false by default
+  * A watchdog that tries to ensure that no Firefox instance takes up too much memory. It is set to false by default
   * It is mostly useful for long running cloud crawls
 
 # Browser Configuration Options
@@ -322,7 +322,7 @@ but will not be used during crash recovery. Specifically:
 profile specified by `seed_tar`. If OpenWPM determines that Firefox needs to
 restart for some reason during the crawl, it will use the profile from
 the most recent page visit (pre-crash) rather than the `seed_tar` profile.
-Note that stateful crawl are currently [unsupported](https://github.com/mozilla/OpenWPM/projects/2)).
+Note that stateful crawls are currently [unsupported](https://github.com/mozilla/OpenWPM/projects/2)).
 * For stateless crawls, the initial `seed_tar` will be loaded during each
 new page visit. Note that this means the profile will very likely be
 _incomplete_, as cookies or storage may have been set or changed during the

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -72,6 +72,9 @@ validate_crawl_configs(manager_params, browser_params)
     `CommandExecutionError` exception. Otherwise the default is set to 2 x the
     number of browsers plus 10. The failure counter is reset at the end of each
     successfully completed command sequence.
+  * For non-blocking command sequences that cause the number of failures to
+    exceed `failure_limit` the `CommandExecutionError` is raised when
+    attempting to execute the next command sequence.
 * `testing`
   * A platform wide flag that can be used to only run certain functionality
     while testing. For example, the Javascript instrumentation

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -68,9 +68,10 @@ validate_crawl_configs(manager_params, browser_params)
 * `database_name` -> supported file extensions are `.db`, `.sqlite`
   * The name of the database file to be written to `data_directory`
 * `failure_limit` -> has to be either of type `int` or `None`
-  * The number of successive command failures the platform will tolerate before
-    raising a `CommandExecutionError` exception. Otherwise the default is set
-    to 2 x the number of browsers plus 10.
+  * The number of command failures the platform will tolerate before raising a
+    `CommandExecutionError` exception. Otherwise the default is set to 2 x the
+    number of browsers plus 10. The failure counter is reset at the end of each
+    successfully completed command sequence.
 * `testing`
   * A platform wide flag that can be used to only run certain functionality
     while testing. For example, the Javascript instrumentation

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -107,13 +107,23 @@ class ManagerParams:
     output_format: str = "local"
     database_name: str = "crawl-data.sqlite"
     log_file: str = "openwpm.log"
-    failure_limit: Optional[int] = None
     testing: bool = False
     s3_bucket: Optional[str] = None
     s3_directory: Optional[str] = None
     memory_watchdog: bool = False
     process_watchdog: bool = False
     num_browsers: int = 1
+    _failure_limit: Optional[int] = None
+
+    @property
+    def failure_limit(self):
+        if self._failure_limit is None:
+            return 2 * self.num_browsers + 10
+        return self._failure_limit
+
+    @failure_limit.setter
+    def failure_limit(self, value):
+        self._failure_limit = value
 
 
 @dataclass
@@ -237,12 +247,8 @@ def validate_manager_params(manager_params: ManagerParams) -> None:
             )
         )
 
-    # This check is necessary to not cause any internal error because
-    # failure_limit gets set in TaskManager if its value is anything other than None
-    if (
-        not isinstance(manager_params.failure_limit, int)
-        and manager_params.failure_limit is not None
-    ):
+    # This check is necessary to not cause any internal error
+    if not isinstance(manager_params.failure_limit, int):
         raise ConfigError(
             GENERAL_ERROR_STRING.format(
                 value=manager_params.failure_limit,

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -116,13 +116,13 @@ class ManagerParams:
     _failure_limit: Optional[int] = None
 
     @property
-    def failure_limit(self):
+    def failure_limit(self) -> int:
         if self._failure_limit is None:
             return 2 * self.num_browsers + 10
         return self._failure_limit
 
     @failure_limit.setter
-    def failure_limit(self, value):
+    def failure_limit(self, value) -> None:
         self._failure_limit = value
 
 

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -23,6 +23,7 @@ from openwpm.config import (
 
 from .browser_manager import Browser
 from .command_sequence import CommandSequence
+from .commands.browser_commands import FinalizeCommand
 from .commands.utils.webdriver_utils import parse_neterror
 from .DataAggregator import S3_aggregator, base_aggregator, local_aggregator
 from .DataAggregator.base_aggregator import ACTION_TYPE_FINALIZE, RECORD_TYPE_SPECIAL
@@ -561,8 +562,8 @@ class TaskManager:
                 self.logger.debug(
                     "BROWSER %i: Browser restart required" % (browser.browser_id)
                 )
-
-            else:
+            # Reset failure_count at the end of each successful command sequence
+            elif type(command) is FinalizeCommand:
                 with self.threadlock:
                     self.failure_count = 0
 

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -125,7 +125,7 @@ class TaskManager:
         self.closing = False
         self.failure_status: Optional[Dict[str, Any]] = None
         self.threadlock = threading.Lock()
-        self.failurecount = 0
+        self.failure_count = 0
 
         self.failure_limit = manager_params.failure_limit
 
@@ -545,8 +545,8 @@ class TaskManager:
 
             if command_status != "ok":
                 with self.threadlock:
-                    self.failurecount += 1
-                if self.failurecount > self.failure_limit:
+                    self.failure_count += 1
+                if self.failure_count > self.failure_limit:
                     self.logger.critical(
                         "BROWSER %i: Command execution failure pushes failure "
                         "count above the allowable limit. Setting "
@@ -564,7 +564,7 @@ class TaskManager:
 
             else:
                 with self.threadlock:
-                    self.failurecount = 0
+                    self.failure_count = 0
 
             if browser.restart_required:
                 self.sock.send(

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -127,10 +127,7 @@ class TaskManager:
         self.threadlock = threading.Lock()
         self.failurecount = 0
 
-        if manager_params.failure_limit:
-            self.failure_limit = manager_params.failure_limit
-        else:
-            self.failure_limit = self.num_browsers * 2 + 10
+        self.failure_limit = manager_params.failure_limit
 
         # Start logging server thread
         self.logging_server = MPLogger(

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -29,15 +29,6 @@ class TestProfile(OpenWPMTest):
         manager.close()
         assert isfile(join(browser_params[0].profile_archive_dir, "profile.tar.gz"))
 
-    def test_crash(self):
-        manager_params, browser_params = self.get_config()
-        manager_params.failure_limit = 0
-        manager = TaskManager(manager_params, browser_params)
-        with pytest.raises(CommandExecutionError):
-            manager.get("http://example.com")  # So we have a profile
-            manager.get("example.com")  # Selenium requires scheme prefix
-            manager.get("example.com")  # Requires two commands to shut down
-
     @pytest.mark.xfail(run=False)
     def test_crash_profile(self):
         manager_params, browser_params = self.get_config()

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -29,7 +29,6 @@ class TestProfile(OpenWPMTest):
         manager.close()
         assert isfile(join(browser_params[0].profile_archive_dir, "profile.tar.gz"))
 
-    @pytest.mark.xfail(run=False)
     def test_crash(self):
         manager_params, browser_params = self.get_config()
         manager_params.failure_limit = 0

--- a/test/test_task_manager.py
+++ b/test/test_task_manager.py
@@ -1,0 +1,42 @@
+import pytest
+
+from openwpm.errors import CommandExecutionError
+from openwpm.task_manager import TaskManager
+
+from .openwpmtest import OpenWPMTest
+
+
+class TestTaskManager(OpenWPMTest):
+    """Test TaskManager functionality."""
+
+    def get_config(self, data_dir=""):
+        return self.get_test_config(data_dir)
+
+    def test_failure_limit_value(self):
+        manager_params, _ = self.get_config()
+        # The default value for failure_limit is 2 * num_browsers + 10
+        assert manager_params.failure_limit == 12
+        manager_params.failure_limit = 2
+        # Test that the chosen value is not overwritten by the default
+        assert manager_params.failure_limit == 2
+
+    def test_failure_limit_exceeded(self):
+        manager_params, browser_params = self.get_config()
+        manager_params.failure_limit = 0
+        manager = TaskManager(manager_params, browser_params)
+        with pytest.raises(CommandExecutionError):
+            manager.get("example.com")  # Selenium requires scheme prefix
+            manager.get("example.com")  # Requires two commands to shut down
+
+    def test_failure_limit_reset(self):
+        """Test that failure_count is reset on command sequence completion."""
+        manager_params, browser_params = self.get_config()
+        manager_params.failure_limit = 1
+        manager = TaskManager(manager_params, browser_params)
+        manager.get("example.com")  # Selenium requires scheme prefix
+        manager.get("http://example.com")  # Successful command sequence
+        # Now failure_count should be reset to 0 and the following command
+        # failure should not raise a CommandExecutionError
+        manager.get("example.com")  # Selenium requires scheme prefix
+        manager.get("https://example.com")  # Requires two commands to shut down
+        manager.close()

--- a/test/test_task_manager.py
+++ b/test/test_task_manager.py
@@ -4,6 +4,7 @@ from openwpm.errors import CommandExecutionError
 from openwpm.task_manager import TaskManager
 
 from .openwpmtest import OpenWPMTest
+from .utilities import BASE_TEST_URL
 
 
 class TestTaskManager(OpenWPMTest):
@@ -34,9 +35,9 @@ class TestTaskManager(OpenWPMTest):
         manager_params.failure_limit = 1
         manager = TaskManager(manager_params, browser_params)
         manager.get("example.com")  # Selenium requires scheme prefix
-        manager.get("http://example.com")  # Successful command sequence
+        manager.get(BASE_TEST_URL)  # Successful command sequence
         # Now failure_count should be reset to 0 and the following command
         # failure should not raise a CommandExecutionError
         manager.get("example.com")  # Selenium requires scheme prefix
-        manager.get("https://example.com")  # Requires two commands to shut down
+        manager.get(BASE_TEST_URL)  # Requires two commands to shut down
         manager.close()


### PR DESCRIPTION
This PR will close #851. 

It does mainly two things:
1. Moves setting the default value of the `failure_limit` config option from the `TaskManager` to `config.py`
2. Corrects the behavior of `failure_limit` by reseting `failure_count` to 0 after every successfully completed command sequence instead of after every successful command. 
