### PR TITLE
Restore stateful crawling support

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -65,7 +65,6 @@ with TaskManager(
         command_sequence = CommandSequence(
             site,
             site_rank=index,
-            reset=True,
             callback=callback,
         )
 

--- a/demo.py
+++ b/demo.py
@@ -73,5 +73,5 @@ with TaskManager(
         # Have a look at custom_command.py to see how to implement your own command
         command_sequence.append_command(LinkCountingCommand())
 
-        # Run commands across the three browsers (simple parallelization)
+        # Run commands across all browsers (simple parallelization)
         manager.execute_command_sequence(command_sequence)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -249,11 +249,6 @@ TODO
 
 # Browser Profile Support
 
-**WARNING: Stateful crawls are currently not supported. Attempts to run
-stateful crawls will throw `NotImplementedError`s. The work required to
-restore support is tracked in
-[this project](https://github.com/mozilla/OpenWPM/projects/2).**
-
 ## Stateful vs Stateless crawls
 
 By default OpenWPM performs a "stateful" crawl, in that it keeps a consistent
@@ -323,7 +318,6 @@ but will not be used during crash recovery. Specifically:
 profile specified by `seed_tar`. If OpenWPM determines that Firefox needs to
 restart for some reason during the crawl, it will use the profile from
 the most recent page visit (pre-crash) rather than the `seed_tar` profile.
-Note that stateful crawls are currently [unsupported](https://github.com/mozilla/OpenWPM/projects/2)).
 * For stateless crawls, the initial `seed_tar` will be loaded during each
 new page visit. Note that this means the profile will very likely be
 _incomplete_, as cookies or storage may have been set or changed during the

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -1,6 +1,6 @@
 # Release Checklist
 
-We aim to release a new version of OpenWPM with each new Firefox release (~1 release per month). The following steps are necessary for a release
+We aim to release a new version of OpenWPM with each new Firefox release (~1 release per month). The following steps are necessary for a release:
 
 1. Upgrade Firefox to the newest version.
     1. Go to: https://hg.mozilla.org/releases/mozilla-release/tags.
@@ -10,10 +10,11 @@ We aim to release a new version of OpenWPM with each new Firefox release (~1 rel
     1. Run `npm update` in `openwpm/Extension/firefox`.
     2. Run `npm update` in `openwpm/Extension/webext-instrumentation`.
 3. Update python and system dependencies by following the ["managing requirements" instructions](../CONTRIBUTING.md#managing-requirements).
-4. Increment the version number in [VERSION](../VERSION)
-5. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
-6. Squash and merge the release PR to master.
-7. Publish a new release from https://github.com/mozilla/OpenWPM/releases:
+4. If a new version of geckodriver is used, check whether the default geckodriver browser preferences in [`openwpm/deploy_browsers/configure_firefox.py`](../openwpm/deploy_browsers/configure_firefox.py#L8L65) need to be updated.
+5. Increment the version number in [VERSION](../VERSION)
+6. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
+7. Squash and merge the release PR to master.
+8. Publish a new release from https://github.com/mozilla/OpenWPM/releases:
     1. Click "Draft a new release".
     2. Enter the "Tag version" and "Release title" as `vX.X.X`.
     3. In the description:

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -104,7 +104,7 @@ class Browser:
         # to be a tar of the crashed browser's history
         if self.current_profile_path is not None:
             # tar contents of crashed profile to a temp dir
-            tempdir = tempfile.mkdtemp(prefix="owpm_profile_archive_")
+            tempdir = tempfile.mkdtemp(prefix="openwpm_profile_archive_")
             tar_path = Path(tempdir) / "profile.tar.gz"
 
             self.browser_params.profile_path = self.current_profile_path

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -65,7 +65,7 @@ class Browser:
 
         # Queues and process IDs for BrowserManager
 
-        # thread to run commands issues from TaskManager
+        # thread to run commands issued from TaskManager
         self.command_thread: Optional[threading.Thread] = None
         # queue for passing command tuples to BrowserManager
         self.command_queue: Optional[Queue] = None
@@ -78,7 +78,7 @@ class Browser:
         # the port of the display for the Xvfb display (if it exists)
         self.display_port: Optional[int] = None
 
-        # boolean that says if the BrowserManager new (to optimize restarts)
+        # boolean that says if the BrowserManager is new (to optimize restarts)
         self.is_fresh = True
         # boolean indicating if the browser should be restarted
         self.restart_required = False
@@ -210,7 +210,7 @@ class Browser:
         # current profile path class variable and clean up the tempdir
         # and previous profile path.
         if success:
-            self.logger.debug("BROWSER %i: Browser spawn sucessful!" % self.browser_id)
+            self.logger.debug("BROWSER %i: Browser spawn successful!" % self.browser_id)
             previous_profile_path = self.current_profile_path
             self.current_profile_path = browser_profile_path
             if previous_profile_path is not None:
@@ -360,7 +360,7 @@ class Browser:
                 os.kill(self.display_pid, signal.SIGKILL)
             except OSError:
                 self.logger.debug(
-                    "BROWSER %i: Display process does not " "exit" % self.browser_id
+                    "BROWSER %i: Display process does not exit" % self.browser_id
                 )
                 pass
             except TypeError:
@@ -368,7 +368,7 @@ class Browser:
                     "BROWSER %i: PID may not be the correct "
                     "type %s" % (self.browser_id, str(self.display_pid))
                 )
-        if self.display_port is not None:  # xvfb diplay lock
+        if self.display_port is not None:  # xvfb display lock
             lockfile = "/tmp/.X%s-lock" % self.display_port
             try:
                 os.remove(lockfile)

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -190,7 +190,6 @@ class Browser:
                 unsuccessful_spawns += 1
                 error_string = ""
                 status_strings = [
-                    "Proxy Ready",
                     "Profile Created",
                     "Profile Tar",
                     "Display",

--- a/openwpm/command_sequence.py
+++ b/openwpm/command_sequence.py
@@ -10,6 +10,7 @@ from .commands.browser_commands import (
     SaveScreenshotCommand,
     ScreenshotFullPageCommand,
 )
+from .commands.profile_commands import DumpProfileCommand
 from .commands.types import BaseCommand
 from .errors import CommandExecutionError
 
@@ -86,16 +87,10 @@ class CommandSequence:
         self._commands_with_timeout.append((command, timeout))
         self.contains_get_or_browse = True
 
-    def dump_profile(
-        self, dump_folder, close_webdriver=False, compress=True, timeout=120
-    ):
+    def dump_profile(self, tar_path, close_webdriver=False, compress=True, timeout=120):
         """ dumps from the profile path to a given file (absolute path) """
-        raise NotImplementedError(
-            "Profile saving is currently unsupported. "
-            "See: https://github.com/mozilla/OpenWPM/projects/2."
-        )
         self.total_timeout += timeout
-        command = DumpProfCommand(dump_folder, close_webdriver, compress)
+        command = DumpProfileCommand(tar_path, close_webdriver, compress)
         self._commands_with_timeout.append((command, timeout))
 
     def save_screenshot(self, suffix="", timeout=30):
@@ -131,7 +126,7 @@ class CommandSequence:
         self.total_timeout += timeout
         if not self.contains_get_or_browse:
             raise CommandExecutionError(
-                "No get or browse request preceding " "the dump page source command",
+                "No get or browse request preceding the dump page source command",
                 self,
             )
         command = ScreenshotFullPageCommand(suffix)

--- a/openwpm/command_sequence.py
+++ b/openwpm/command_sequence.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Callable, List, Tuple
 
 from .commands.browser_commands import (
@@ -87,7 +88,13 @@ class CommandSequence:
         self._commands_with_timeout.append((command, timeout))
         self.contains_get_or_browse = True
 
-    def dump_profile(self, tar_path, close_webdriver=False, compress=True, timeout=120):
+    def dump_profile(
+        self,
+        tar_path: Path,
+        close_webdriver: bool = False,
+        compress: bool = True,
+        timeout: int = 120,
+    ) -> None:
         """ dumps from the profile path to a given file (absolute path) """
         self.total_timeout += timeout
         command = DumpProfileCommand(tar_path, close_webdriver, compress)

--- a/openwpm/command_sequence.py
+++ b/openwpm/command_sequence.py
@@ -20,7 +20,7 @@ class CommandSequence:
     """A CommandSequence wraps a series of commands to be performed
     on a visit to one top-level site into one logical
     "site visit," keyed by a visit id. An example of a CommandSequence
-    that visits a page and dumps cookies modified on that visit would be:
+    that visits a page and saves a screenshot of it would be:
 
     sequence = CommandSequence(url)
     sequence.get()
@@ -105,7 +105,7 @@ class CommandSequence:
         self.total_timeout += timeout
         if not self.contains_get_or_browse:
             raise CommandExecutionError(
-                "No get or browse request preceding " "the save screenshot command",
+                "No get or browse request preceding the save screenshot command",
                 self,
             )
         command = SaveScreenshotCommand(suffix)
@@ -133,7 +133,7 @@ class CommandSequence:
         self.total_timeout += timeout
         if not self.contains_get_or_browse:
             raise CommandExecutionError(
-                "No get or browse request preceding the dump page source command",
+                "No get or browse request preceding the screenshot full page command",
                 self,
             )
         command = ScreenshotFullPageCommand(suffix)
@@ -144,7 +144,7 @@ class CommandSequence:
         self.total_timeout += timeout
         if not self.contains_get_or_browse:
             raise CommandExecutionError(
-                "No get or browse request preceding " "the dump page source command",
+                "No get or browse request preceding the dump page source command",
                 self,
             )
         command = DumpPageSourceCommand(suffix)
@@ -173,7 +173,8 @@ class CommandSequence:
         self.total_timeout += timeout
         if not self.contains_get_or_browse:
             raise CommandExecutionError(
-                "No get or browse request preceding " "the dump page source command",
+                "No get or browse request preceding the recursive dump"
+                " page source command",
                 self,
             )
         command = RecursiveDumpPageSourceCommand(suffix)
@@ -190,7 +191,6 @@ class CommandSequence:
         """Returns a list of all commands in the command_sequence
         appended by a finalize command
         """
-
         commands = list(self._commands_with_timeout)
         commands.insert(0, (InitializeCommand(), 10))
         commands.append((FinalizeCommand(sleep=5), 10))

--- a/openwpm/commands/profile_commands.py
+++ b/openwpm/commands/profile_commands.py
@@ -134,28 +134,16 @@ def load_profile(
     Loads a zipped cookie-based profile stored at <tar_path> and unzips
     it to <browser_profile_path>. The tar will remain unmodified.
     """
-
     assert browser_params.browser_id is not None
     try:
         assert tar_path.is_file()
-        # Copy and untar the loaded profile
-        logger.debug(
-            "BROWSER %i: Copying profile tar from %s to %s"
-            % (
-                browser_params.browser_id,
-                tar_path,
-                browser_profile_path,
-            )
-        )
-        shutil.copy(tar_path, browser_profile_path)
-        tar_path = browser_profile_path / tar_path.name
+        # Untar the loaded profile
         if tar_path.name.endswith("tar.gz"):
             f = tarfile.open(tar_path, "r:gz", errorlevel=1)
         else:
             f = tarfile.open(tar_path, "r", errorlevel=1)
         f.extractall(browser_profile_path)
         f.close()
-        tar_path.unlink()
         logger.debug("BROWSER %i: Tarfile extracted" % browser_params.browser_id)
 
     except Exception as ex:

--- a/openwpm/commands/profile_commands.py
+++ b/openwpm/commands/profile_commands.py
@@ -2,7 +2,6 @@ import logging
 import shutil
 import tarfile
 from pathlib import Path
-from typing import Optional
 
 from selenium.webdriver import Firefox
 
@@ -16,13 +15,85 @@ from .utils.firefox_profile import sleep_until_sqlite_checkpoint
 logger = logging.getLogger("openwpm")
 
 
+def dump_profile(
+    browser_profile_path: Path,
+    tar_path: Path,
+    compress: bool,
+    browser_params: BrowserParamsInternal,
+) -> None:
+    """Dumps a browser profile to a tar file."""
+    assert browser_params.browser_id is not None
+
+    # Creating the folders if need be
+    tar_path.parent.mkdir(exist_ok=True, parents=True)
+
+    # see if this file exists first
+    # if it does, delete it before we try to save the current session
+    if tar_path.exists():
+        tar_path.unlink()
+
+    # backup and tar profile
+    if compress:
+        tar = tarfile.open(tar_path, "w:gz", errorlevel=1)
+    else:
+        tar = tarfile.open(tar_path, "w", errorlevel=1)
+    logger.debug(
+        "BROWSER %i: Backing up full profile from %s to %s"
+        % (browser_params.browser_id, browser_profile_path, tar_path)
+    )
+
+    storage_vector_files = [
+        "cookies.sqlite",  # cookies
+        "cookies.sqlite-shm",
+        "cookies.sqlite-wal",
+        "places.sqlite",  # history
+        "places.sqlite-shm",
+        "places.sqlite-wal",
+        "webappsstore.sqlite",  # localStorage
+        "webappsstore.sqlite-shm",
+        "webappsstore.sqlite-wal",
+    ]
+    storage_vector_dirs = [
+        "webapps",  # related to localStorage?
+        "storage",  # directory for IndexedDB
+    ]
+    for item in storage_vector_files:
+        full_path = browser_profile_path / item
+        if (
+            not full_path.is_file()
+            and not full_path.name.endswith("shm")
+            and not full_path.name.endswith("wal")
+        ):
+            logger.critical(
+                "BROWSER %i: %s NOT FOUND IN profile folder, skipping."
+                % (browser_params.browser_id, full_path)
+            )
+        elif not full_path.is_file() and (
+            full_path.name.endswith("shm") or full_path.name.endswith("wal")
+        ):
+            continue  # These are just checkpoint files
+        tar.add(full_path, arcname=item)
+    for item in storage_vector_dirs:
+        full_path = browser_profile_path / item
+        if not full_path.is_dir():
+            logger.warning(
+                "BROWSER %i: %s NOT FOUND IN profile folder, skipping."
+                % (browser_params.browser_id, full_path)
+            )
+            continue
+        tar.add(full_path, arcname=item)
+    tar.close()
+
+
 class DumpProfileCommand(BaseCommand):
     """
     Dumps a browser profile currently stored in <browser_params.profile_path> to
     <tar_path>.
     """
 
-    def __init__(self, tar_path: Path, close_webdriver: bool, compress: bool) -> None:
+    def __init__(
+        self, tar_path: Path, close_webdriver: bool, compress: bool = True
+    ) -> None:
         self.tar_path = tar_path
         self.close_webdriver = close_webdriver
         self.compress = compress
@@ -37,78 +108,20 @@ class DumpProfileCommand(BaseCommand):
         webdriver: Firefox,
         browser_params: BrowserParamsInternal,
         manager_params: ManagerParamsInternal,
-        extension_socket: Optional[ClientSocket],
+        extension_socket: ClientSocket,
     ) -> None:
-        browser_profile_path = browser_params.profile_path
-        assert browser_profile_path is not None
-        assert browser_params.browser_id is not None
-
-        # Creating the folders if need be
-        self.tar_path.parent.mkdir(exist_ok=True, parents=True)
-
-        # see if this file exists first
-        # if it does, delete it before we try to save the current session
-        if self.tar_path.exists():
-            self.tar_path.unlink()  # IDK why it's called like this
         # if this is a dump on close, close the webdriver and wait for checkpoint
         if self.close_webdriver:
             webdriver.close()
-            sleep_until_sqlite_checkpoint(browser_profile_path)
+            sleep_until_sqlite_checkpoint(browser_params.profile_path)
 
-        # backup and tar profile
-        if self.compress:
-            tar = tarfile.open(self.tar_path, "w:gz", errorlevel=1)
-        else:
-            tar = tarfile.open(self.tar_path, "w", errorlevel=1)
-        logger.debug(
-            "BROWSER %i: Backing up full profile from %s to %s"
-            % (
-                browser_params.browser_id,
-                browser_profile_path,
-                self.tar_path,
-            )
+        assert browser_params.profile_path is not None
+        dump_profile(
+            browser_params.profile_path,
+            self.tar_path,
+            self.compress,
+            browser_params,
         )
-        storage_vector_files = [
-            "cookies.sqlite",  # cookies
-            "cookies.sqlite-shm",
-            "cookies.sqlite-wal",
-            "places.sqlite",  # history
-            "places.sqlite-shm",
-            "places.sqlite-wal",
-            "webappsstore.sqlite",  # localStorage
-            "webappsstore.sqlite-shm",
-            "webappsstore.sqlite-wal",
-        ]
-        storage_vector_dirs = [
-            "webapps",  # related to localStorage?
-            "storage",  # directory for IndexedDB
-        ]
-        for item in storage_vector_files:
-            full_path = browser_profile_path / item
-            if (
-                not full_path.is_file()
-                and not full_path.name.endswith("shm")
-                and not full_path.name.endswith("wal")
-            ):
-                logger.critical(
-                    "BROWSER %i: %s NOT FOUND IN profile folder, skipping."
-                    % (browser_params.browser_id, full_path)
-                )
-            elif not full_path.is_file() and (
-                full_path.name.endswith("shm") or full_path.name.endswith("wal")
-            ):
-                continue  # These are just checkpoint files
-            tar.add(full_path, arcname=item)
-        for item in storage_vector_dirs:
-            full_path = browser_profile_path / item
-            if not full_path.is_dir():
-                logger.warning(
-                    "BROWSER %i: %s NOT FOUND IN profile folder, skipping."
-                    % (browser_params.browser_id, full_path)
-                )
-                continue
-            tar.add(full_path, arcname=item)
-        tar.close()
 
 
 def load_profile(

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -97,7 +97,9 @@ class BrowserParams(DataClassJsonMixin):
     prefs: dict = field(default_factory=dict)
     tp_cookies: str = "always"
     bot_mitigation: bool = False
-    profile_archive_dir: Optional[str] = None
+    profile_archive_dir: Optional[Path] = field(
+        default=None, metadata=DCJConfig(encoder=path_to_str, decoder=str_to_path)
+    )
     recovery_tar: Optional[Path] = None
     donottrack: bool = False
     tracking_protection: bool = False

--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -5,8 +5,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict
 
-# TODO: Remove hardcoded geckodriver default preferences once
-# https://github.com/mozilla/geckodriver/issues/1844 is fixed.
+# TODO: Remove hardcoded geckodriver default preferences. See
+# https://github.com/mozilla/OpenWPM/issues/867
 # Source of preferences:
 # https://hg.mozilla.org/mozilla-central/file/tip/testing/geckodriver/src/prefs.rs
 # https://hg.mozilla.org/mozilla-central/file/tip/testing/geckodriver/src/marionette.rs

--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -1,7 +1,7 @@
 """ Set prefs and load extensions in Firefox """
 
 
-def privacy(browser_params, fp, fo, root_dir, browser_profile_path):
+def privacy(browser_params, fo):
     """
     Configure the privacy settings in Firefox. This includes:
     * DNT

--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -241,7 +241,7 @@ def optimize_prefs(prefs: Dict[str, Any]) -> None:
     prefs["app.shield.optoutstudies.enabled"] = False
     prefs["extensions.shield-recipe-client.enabled"] = False
 
-    # Disable Source Pragams
+    # Disable Source Pragmas
     # As per https://bugzilla.mozilla.org/show_bug.cgi?id=1628853
     # sourceURL can be used to obfuscate the original origin of
     # a script, we disable it.

--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -1,7 +1,103 @@
 """ Set prefs and load extensions in Firefox """
 
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict
 
-def privacy(browser_params, fo):
+# TODO: Remove hardcoded geckodriver default preferences once
+# https://github.com/mozilla/geckodriver/issues/1844 is fixed.
+# Source of preferences:
+# https://hg.mozilla.org/mozilla-central/file/tip/testing/geckodriver/src/prefs.rs
+# https://hg.mozilla.org/mozilla-central/file/tip/testing/geckodriver/src/marionette.rs
+DEFAULT_GECKODRIVER_PREFS = {
+    "app.normandy.api_url": "",
+    "app.update.checkInstallTime": False,
+    "app.update.disabledForTesting": True,
+    "app.update.auto": False,
+    "browser.dom.window.dump.enabled": True,
+    "devtools.console.stdout.chrome": True,
+    "browser.safebrowsing.blockedURIs.enabled": False,
+    "browser.safebrowsing.downloads.enabled": False,
+    "browser.safebrowsing.passwords.enabled": False,
+    "browser.safebrowsing.malware.enabled": False,
+    "browser.safebrowsing.phishing.enabled": False,
+    "browser.sessionstore.resume_from_crash": False,
+    "browser.shell.checkDefaultBrowser": False,
+    "browser.startup.homepage_override.mstone": "ignore",
+    "browser.startup.page": 0,
+    "browser.tabs.closeWindowWithLastTab": False,
+    "browser.tabs.warnOnClose": False,
+    "browser.uitour.enabled": False,
+    "browser.warnOnQuit": False,
+    "datareporting.healthreport.documentServerURI": "http://%(server)s/dummy/healthreport/",
+    "datareporting.healthreport.logging.consoleEnabled": False,
+    "datareporting.healthreport.service.enabled": False,
+    "datareporting.healthreport.service.firstRun": False,
+    "datareporting.healthreport.uploadEnabled": False,
+    "datareporting.policy.dataSubmissionEnabled": False,
+    "datareporting.policy.dataSubmissionPolicyBypassNotification": True,
+    "dom.ipc.reportProcessHangs": False,
+    "extensions.autoDisableScopes": 0,
+    "extensions.enabledScopes": 5,
+    "extensions.installDistroAddons": False,
+    "extensions.update.enabled": False,
+    "extensions.update.notifyUser": False,
+    "focusmanager.testmode": True,
+    "general.useragent.updates.enabled": False,
+    "geo.provider.testing": True,
+    "geo.wifi.scan": False,
+    "hangmonitor.timeout": 0,
+    "idle.lastDailyNotification": -1,
+    "javascript.options.showInConsole": True,
+    "media.gmp-manager.updateEnabled": False,
+    "media.sanity-test.disabled": True,
+    "network.http.phishy-userpass-length": 255,
+    "network.manage-offline-status": False,
+    "network.sntp.pools": "%(server)s",
+    "plugin.state.flash": 0,
+    "security.certerrors.mitm.priming.enabled": False,
+    "services.settings.server": "http://%(server)s/dummy/blocklist/",
+    "startup.homepage_welcome_url": "about:blank",
+    "startup.homepage_welcome_url.additional": "",
+    "toolkit.startup.max_resumed_crashes": -1,
+    "marionette.log.level": "Info",
+}
+
+
+def load_existing_prefs(browser_profile_path: Path) -> Dict[str, Any]:
+    """Load existing user preferences.
+
+    If the browser profile contains a user.js file, load the preferences
+    specified inside it into a dictionary.
+    """
+    prefs: Dict[str, Any] = {}
+    prefs_path = browser_profile_path / "user.js"
+    if not prefs_path.is_file():
+        return prefs
+    # Regular expression from https://stackoverflow.com/a/24563687
+    r = re.compile(r"\s*user_pref\(([\"'])(.+?)\1,\s*(.+?)\);")
+    with open(prefs_path, "r") as f:
+        for line in f:
+            m = r.match(line)
+            if m:
+                key, value = m.group(2), m.group(3)
+                prefs[key] = json.loads(value)
+    return prefs
+
+
+def save_prefs_to_profile(prefs: Dict[str, Any], browser_profile_path: Path) -> None:
+    """Save all preferences to the browser profile.
+
+    Write preferences from the prefs dictionary to a user.js file in the
+    profile directory.
+    """
+    with open(browser_profile_path / "user.js", "w") as f:
+        for key, value in prefs.items():
+            f.write('user_pref("%s", %s);\n' % (key, json.dumps(value)))
+
+
+def privacy(browser_params, prefs):
     """
     Configure the privacy settings in Firefox. This includes:
     * DNT
@@ -12,15 +108,15 @@ def privacy(browser_params, fo):
 
     # Turns on Do Not Track
     if browser_params.donottrack:
-        fo.set_preference("privacy.donottrackheader.enabled", True)
+        prefs["privacy.donottrackheader.enabled"] = True
 
     # Sets the third party cookie setting
     if browser_params.tp_cookies.lower() == "never":
-        fo.set_preference("network.cookie.cookieBehavior", 1)
+        prefs["network.cookie.cookieBehavior"] = 1
     elif browser_params.tp_cookies.lower() == "from_visited":
-        fo.set_preference("network.cookie.cookieBehavior", 3)
+        prefs["network.cookie.cookieBehavior"] = 3
     else:  # always allow third party cookies
-        fo.set_preference("network.cookie.cookieBehavior", 0)
+        prefs["network.cookie.cookieBehavior"] = 0
 
     # Tracking Protection
     if browser_params.tracking_protection:
@@ -31,7 +127,7 @@ def privacy(browser_params, fo):
         )
 
 
-def optimize_prefs(fo):
+def optimize_prefs(prefs):
     """
     Disable various features and checks the browser will do on startup.
     Some of these (e.g. disabling the newtab page) are required to prevent
@@ -42,113 +138,113 @@ def optimize_prefs(fo):
     * https://github.com/pyllyukko/user.js/blob/master/user.js
     """  # noqa
     # Startup / Speed
-    fo.set_preference("browser.shell.checkDefaultBrowser", False)
-    fo.set_preference("browser.slowStartup.notificationDisabled", True)
-    fo.set_preference("browser.slowStartup.maxSamples", 0)
-    fo.set_preference("browser.slowStartup.samples", 0)
-    fo.set_preference("extensions.checkCompatibility.nightly", False)
-    fo.set_preference("browser.rights.3.shown", True)
-    fo.set_preference("reader.parse-on-load.enabled", False)
-    fo.set_preference("browser.pagethumbnails.capturing_disabled", True)
-    fo.set_preference("browser.uitour.enabled", False)
-    fo.set_preference("dom.flyweb.enabled", False)
+    prefs["browser.shell.checkDefaultBrowser"] = False
+    prefs["browser.slowStartup.notificationDisabled"] = True
+    prefs["browser.slowStartup.maxSamples"] = 0
+    prefs["browser.slowStartup.samples"] = 0
+    prefs["extensions.checkCompatibility.nightly"] = False
+    prefs["browser.rights.3.shown"] = True
+    prefs["reader.parse-on-load.enabled"] = False
+    prefs["browser.pagethumbnails.capturing_disabled"] = True
+    prefs["browser.uitour.enabled"] = False
+    prefs["dom.flyweb.enabled"] = False
 
     # Disable health reports / telemetry / crash reports
-    fo.set_preference("datareporting.policy.dataSubmissionEnabled", False)
-    fo.set_preference("datareporting.healthreport.uploadEnabled", False)
-    fo.set_preference("datareporting.healthreport.service.enabled", False)
-    fo.set_preference("toolkit.telemetry.archive.enabled", False)
-    fo.set_preference("toolkit.telemetry.enabled", False)
-    fo.set_preference("toolkit.telemetry.unified", False)
-    fo.set_preference("breakpad.reportURL", "")
-    fo.set_preference("dom.ipc.plugins.reportCrashURL", False)
-    fo.set_preference("browser.selfsupport.url", "")
-    fo.set_preference("browser.tabs.crashReporting.sendReport", False)
-    fo.set_preference("browser.crashReports.unsubmittedCheck.enabled", False)
-    fo.set_preference("dom.ipc.plugins.flash.subprocess.crashreporter.enabled", False)
+    prefs["datareporting.policy.dataSubmissionEnabled"] = False
+    prefs["datareporting.healthreport.uploadEnabled"] = False
+    prefs["datareporting.healthreport.service.enabled"] = False
+    prefs["toolkit.telemetry.archive.enabled"] = False
+    prefs["toolkit.telemetry.enabled"] = False
+    prefs["toolkit.telemetry.unified"] = False
+    prefs["breakpad.reportURL"] = ""
+    prefs["dom.ipc.plugins.reportCrashURL"] = False
+    prefs["browser.selfsupport.url"] = ""
+    prefs["browser.tabs.crashReporting.sendReport"] = False
+    prefs["browser.crashReports.unsubmittedCheck.enabled"] = False
+    prefs["dom.ipc.plugins.flash.subprocess.crashreporter.enabled"] = False
 
     # Predictive Actions / Prefetch
-    fo.set_preference("network.predictor.enabled", False)
-    fo.set_preference("network.dns.disablePrefetch", True)
-    fo.set_preference("network.prefetch-next", False)
-    fo.set_preference("browser.search.suggest.enabled", False)
-    fo.set_preference("network.http.speculative-parallel-limit", 0)
-    fo.set_preference("keyword.enabled", False)  # location bar using search
-    fo.set_preference("browser.urlbar.userMadeSearchSuggestionsChoice", True)
-    fo.set_preference("browser.casting.enabled", False)
+    prefs["network.predictor.enabled"] = False
+    prefs["network.dns.disablePrefetch"] = True
+    prefs["network.prefetch-next"] = False
+    prefs["browser.search.suggest.enabled"] = False
+    prefs["network.http.speculative-parallel-limit"] = 0
+    prefs["keyword.enabled"] = False  # location bar using search
+    prefs["browser.urlbar.userMadeSearchSuggestionsChoice"] = True
+    prefs["browser.casting.enabled"] = False
 
     # Disable pinging Mozilla for geoip
-    fo.set_preference("browser.search.geoip.url", "")
-    fo.set_preference("browser.search.countryCode", "US")
-    fo.set_preference("browser.search.region", "US")
+    prefs["browser.search.geoip.url"] = ""
+    prefs["browser.search.countryCode"] = "US"
+    prefs["browser.search.region"] = "US"
 
     # Disable pinging Mozilla for geo-specific search
-    fo.set_preference("browser.search.geoSpecificDefaults", False)
-    fo.set_preference("browser.search.geoSpecificDefaults.url", "")
+    prefs["browser.search.geoSpecificDefaults"] = False
+    prefs["browser.search.geoSpecificDefaults.url"] = ""
 
     # Disable auto-updating
-    fo.set_preference("app.update.enabled", False)  # browser
-    fo.set_preference("app.update.url", "")  # browser
-    fo.set_preference("browser.search.update", False)  # search
-    fo.set_preference("extensions.update.enabled", False)  # extensions
-    fo.set_preference("extensions.update.autoUpdateDefault", False)
-    fo.set_preference("extensions.getAddons.cache.enabled", False)
-    fo.set_preference("lightweightThemes.update.enabled", False)  # Personas
+    prefs["app.update.enabled"] = False  # browser
+    prefs["app.update.url"] = ""  # browser
+    prefs["browser.search.update"] = False  # search
+    prefs["extensions.update.enabled"] = False  # extensions
+    prefs["extensions.update.autoUpdateDefault"] = False
+    prefs["extensions.getAddons.cache.enabled"] = False
+    prefs["lightweightThemes.update.enabled"] = False  # Personas
 
     # Disable Safebrowsing and other security features
     # that require on remote content
-    fo.set_preference("browser.safebrowsing.phising.enabled", False)
-    fo.set_preference("browser.safebrowsing.malware.enabled", False)
-    fo.set_preference("browser.safebrowsing.downloads.enabled", False)
-    fo.set_preference("browser.safebrowsing.downloads.remote.enabled", False)
-    fo.set_preference("browser.safebrowsing.blockedURIs.enabled", False)
-    fo.set_preference("browser.safebrowsing.provider.mozilla.gethashURL", "")
-    fo.set_preference("browser.safebrowsing.provider.google.gethashURL", "")
-    fo.set_preference("browser.safebrowsing.provider.google4.gethashURL", "")
-    fo.set_preference("browser.safebrowsing.provider.mozilla.updateURL", "")
-    fo.set_preference("browser.safebrowsing.provider.google.updateURL", "")
-    fo.set_preference("browser.safebrowsing.provider.google4.updateURL", "")
-    fo.set_preference("browser.safebrowsing.provider.mozilla.lists", "")  # TP
-    fo.set_preference("browser.safebrowsing.provider.google.lists", "")  # TP
-    fo.set_preference("browser.safebrowsing.provider.google4.lists", "")  # TP
-    fo.set_preference("extensions.blocklist.enabled", False)  # extensions
-    fo.set_preference("security.OCSP.enabled", 0)
+    prefs["browser.safebrowsing.phising.enabled"] = False
+    prefs["browser.safebrowsing.malware.enabled"] = False
+    prefs["browser.safebrowsing.downloads.enabled"] = False
+    prefs["browser.safebrowsing.downloads.remote.enabled"] = False
+    prefs["browser.safebrowsing.blockedURIs.enabled"] = False
+    prefs["browser.safebrowsing.provider.mozilla.gethashURL"] = ""
+    prefs["browser.safebrowsing.provider.google.gethashURL"] = ""
+    prefs["browser.safebrowsing.provider.google4.gethashURL"] = ""
+    prefs["browser.safebrowsing.provider.mozilla.updateURL"] = ""
+    prefs["browser.safebrowsing.provider.google.updateURL"] = ""
+    prefs["browser.safebrowsing.provider.google4.updateURL"] = ""
+    prefs["browser.safebrowsing.provider.mozilla.lists"] = ""  # TP
+    prefs["browser.safebrowsing.provider.google.lists"] = ""  # TP
+    prefs["browser.safebrowsing.provider.google4.lists"] = ""  # TP
+    prefs["extensions.blocklist.enabled"] = False  # extensions
+    prefs["security.OCSP.enabled"] = 0
 
     # Disable Content Decryption Module and OpenH264 related downloads
-    fo.set_preference("media.gmp-manager.url", "")
-    fo.set_preference("media.gmp-provider.enabled", False)
-    fo.set_preference("media.gmp-widevinecdm.enabled", False)
-    fo.set_preference("media.gmp-widevinecdm.visible", False)
-    fo.set_preference("media.gmp-gmpopenh264.enabled", False)
+    prefs["media.gmp-manager.url"] = ""
+    prefs["media.gmp-provider.enabled"] = False
+    prefs["media.gmp-widevinecdm.enabled"] = False
+    prefs["media.gmp-widevinecdm.visible"] = False
+    prefs["media.gmp-gmpopenh264.enabled"] = False
 
     # Disable Experiments
-    fo.set_preference("experiments.enabled", False)
-    fo.set_preference("experiments.manifest.uri", "")
-    fo.set_preference("experiments.supported", False)
-    fo.set_preference("experiments.activeExperiment", False)
-    fo.set_preference("network.allow-experiments", False)
+    prefs["experiments.enabled"] = False
+    prefs["experiments.manifest.uri"] = ""
+    prefs["experiments.supported"] = False
+    prefs["experiments.activeExperiment"] = False
+    prefs["network.allow-experiments"] = False
 
     # Disable pinging Mozilla for newtab
-    fo.set_preference("browser.newtabpage.directory.ping", "")
-    fo.set_preference("browser.newtabpage.directory.source", "")
-    fo.set_preference("browser.newtabpage.enabled", False)
-    fo.set_preference("browser.newtabpage.enhanced", False)
-    fo.set_preference("browser.newtabpage.introShown", True)
-    fo.set_preference("browser.aboutHomeSnippets.updateUrl", "")
+    prefs["browser.newtabpage.directory.ping"] = ""
+    prefs["browser.newtabpage.directory.source"] = ""
+    prefs["browser.newtabpage.enabled"] = False
+    prefs["browser.newtabpage.enhanced"] = False
+    prefs["browser.newtabpage.introShown"] = True
+    prefs["browser.aboutHomeSnippets.updateUrl"] = ""
 
     # Disable Pocket
-    fo.set_preference("extensions.pocket.enabled", False)
+    prefs["extensions.pocket.enabled"] = False
 
     # Disable Shield
-    fo.set_preference("app.shield.optoutstudies.enabled", False)
-    fo.set_preference("extensions.shield-recipe-client.enabled", False)
+    prefs["app.shield.optoutstudies.enabled"] = False
+    prefs["extensions.shield-recipe-client.enabled"] = False
 
     # Disable Source Pragams
     # As per https://bugzilla.mozilla.org/show_bug.cgi?id=1628853
     # sourceURL can be used to obfuscate the original origin of
     # a script, we disable it.
-    fo.set_preference("javascript.options.source_pragmas", False)
+    prefs["javascript.options.source_pragmas"] = False
 
     # Enable extensions and disable extension signing
-    fo.set_preference("extensions.experiments.enabled", True)
-    fo.set_preference("xpinstall.signatures.required", False)
+    prefs["extensions.experiments.enabled"] = True
+    prefs["xpinstall.signatures.required"] = False

--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict
 
+from ..config import BrowserParams
+
 # TODO: Remove hardcoded geckodriver default preferences. See
 # https://github.com/mozilla/OpenWPM/issues/867
 # Source of preferences:
@@ -97,7 +99,7 @@ def save_prefs_to_profile(prefs: Dict[str, Any], browser_profile_path: Path) -> 
             f.write('user_pref("%s", %s);\n' % (key, json.dumps(value)))
 
 
-def privacy(browser_params, prefs):
+def privacy(browser_params: BrowserParams, prefs: Dict[str, Any]) -> None:
     """
     Configure the privacy settings in Firefox. This includes:
     * DNT
@@ -127,7 +129,7 @@ def privacy(browser_params, prefs):
         )
 
 
-def optimize_prefs(prefs):
+def optimize_prefs(prefs: Dict[str, Any]) -> None:
     """
     Disable various features and checks the browser will do on startup.
     Some of these (e.g. disabling the newtab page) are required to prevent

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -34,7 +34,7 @@ def deploy_firefox(
 
     root_dir = os.path.dirname(__file__)  # directory of this file
 
-    browser_profile_path = Path(tempfile.mkdtemp(".firefox_profile"))
+    browser_profile_path = Path(tempfile.mkdtemp(prefix="firefox_profile_"))
     status_queue.put(("STATUS", "Profile Created", browser_profile_path))
 
     # Use Options instead of FirefoxProfile to set preferences since the
@@ -191,4 +191,4 @@ def deploy_firefox(
 
     status_queue.put(("STATUS", "Browser Launched", int(pid)))
 
-    return driver, Path(driver.capabilities["moz:profile"]), display
+    return driver, browser_profile_path, display

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -126,6 +126,8 @@ def deploy_firefox(
     # Load default geckodriver preferences
     prefs.update(configure_firefox.DEFAULT_GECKODRIVER_PREFS)
     # Pick an available port for Marionette (https://stackoverflow.com/a/2838309)
+    # This has a race condition, as another process may get the port
+    # before Marionette, but we don't expect it to happen often
     s = socket.socket()
     s.bind(("", 0))
     marionette_port = s.getsockname()[1]

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -119,8 +119,8 @@ def deploy_firefox(
 
     # Geckodriver currently places the user.js file in the wrong profile
     # directory, so we have to create it manually here.
-    # TODO: Remove this workaround once
-    # https://github.com/mozilla/geckodriver/issues/1844 is fixed.
+    # TODO: See https://github.com/mozilla/OpenWPM/issues/867 for when
+    # to remove this workaround.
     # Load existing preferences from the profile's user.js file
     prefs = configure_firefox.load_existing_prefs(browser_profile_path)
     # Load default geckodriver preferences
@@ -162,8 +162,8 @@ def deploy_firefox(
         firefox_binary=fb,
         options=fo,
         log_path=interceptor.fifo,
-        # TODO: Remove when https://github.com/mozilla/geckodriver/issues/1844
-        # is fixed
+        # TODO: See https://github.com/mozilla/OpenWPM/issues/867 for
+        # when to remove this
         service_args=["--marionette-port", str(marionette_port)],
     )
 

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -139,9 +139,8 @@ def deploy_firefox(
     configure_firefox.optimize_prefs(prefs)
 
     # Intercept logging at the Selenium level and redirect it to the
-    # main logger.  This will also inform us where the real profile
-    # directory is hiding.
-    interceptor = FirefoxLogInterceptor(browser_params.browser_id, browser_profile_path)
+    # main logger.
+    interceptor = FirefoxLogInterceptor(browser_params.browser_id)
     interceptor.start()
 
     # Set custom prefs. These are set after all of the default prefs to allow

--- a/openwpm/deploy_browsers/selenium_firefox.py
+++ b/openwpm/deploy_browsers/selenium_firefox.py
@@ -129,7 +129,7 @@ class PatchedGeckoDriverService(BaseService):
         self.service_args = service_args or []
 
     def command_line_args(self):
-        return ["--port", "%d" % self.port]
+        return ["--port", "%d" % self.port] + self.service_args
 
     def send_remote_shutdown_command(self):
         pass

--- a/openwpm/deploy_browsers/selenium_firefox.py
+++ b/openwpm/deploy_browsers/selenium_firefox.py
@@ -13,6 +13,7 @@ from selenium.webdriver.common.service import Service as BaseService
 from selenium.webdriver.firefox import webdriver as FirefoxDriverModule
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.firefox.service import Service as FirefoxService
 
 __all__ = ["FirefoxBinary", "FirefoxLogInterceptor", "Options"]
 
@@ -76,7 +77,7 @@ class FirefoxLogInterceptor(threading.Thread):
                 self.fifo = None
 
 
-class PatchedGeckoDriverService(BaseService):
+class PatchedGeckoDriverService(FirefoxService):
     """Object that manages the starting and stopping of the GeckoDriver.
     Modified from the original (selenium.webdriver.firefox.service.Service)
     for Py3 compat in the presence of log FIFOs, and for potential future
@@ -120,12 +121,6 @@ class PatchedGeckoDriverService(BaseService):
             self, executable_path, port=port, log_file=log_file, env=env
         )
         self.service_args = service_args or []
-
-    def command_line_args(self):
-        return ["--port", "%d" % self.port] + self.service_args
-
-    def send_remote_shutdown_command(self):
-        pass
 
 
 FirefoxDriverModule.Service = PatchedGeckoDriverService

--- a/openwpm/deploy_browsers/selenium_firefox.py
+++ b/openwpm/deploy_browsers/selenium_firefox.py
@@ -46,15 +46,13 @@ class FirefoxLogInterceptor(threading.Thread):
     """
     Intercept logs from Selenium and/or geckodriver, using a named pipe
     and a detached thread, and feed them to the primary logger for this
-    instance.  Also responsible for extracting the _real_ profile location
-    from geckodriver's log output (geckodriver copies the profile).
+    instance.
     """
 
-    def __init__(self, browser_id, profile_path):
+    def __init__(self, browser_id):
         threading.Thread.__init__(self, name="log-interceptor-%i" % browser_id)
         self.browser_id = browser_id
         self.fifo = mktempfifo(suffix=".log", prefix="owpm_driver_")
-        self.profile_path = profile_path
         self.daemon = True
         self.logger = logging.getLogger("openwpm")
 
@@ -68,11 +66,6 @@ class FirefoxLogInterceptor(threading.Thread):
                     self.logger.debug(
                         "BROWSER %i: driver: %s" % (self.browser_id, line.strip())
                     )
-                    if "Using profile path" in line:
-                        self.profile_path = line.partition("Using profile path")[
-                            -1
-                        ].strip()
-
                     if self.fifo is not None:
                         os.unlink(self.fifo)
                         self.fifo = None

--- a/openwpm/deploy_browsers/selenium_firefox.py
+++ b/openwpm/deploy_browsers/selenium_firefox.py
@@ -13,7 +13,6 @@ from selenium.webdriver.common.service import Service as BaseService
 from selenium.webdriver.firefox import webdriver as FirefoxDriverModule
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.options import Options
-from selenium.webdriver.firefox.service import Service as FirefoxService
 
 __all__ = ["FirefoxBinary", "FirefoxLogInterceptor", "Options"]
 
@@ -77,7 +76,7 @@ class FirefoxLogInterceptor(threading.Thread):
                 self.fifo = None
 
 
-class PatchedGeckoDriverService(FirefoxService):
+class PatchedGeckoDriverService(FirefoxDriverModule.Service):
     """Object that manages the starting and stopping of the GeckoDriver.
     Modified from the original (selenium.webdriver.firefox.service.Service)
     for Py3 compat in the presence of log FIFOs, and for potential future

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -305,8 +305,8 @@ class TaskManager:
         Parameters
         ----------
         during_init :
-            flag to indicator if this shutdown is occuring during
-          the TaskManager initialization
+            flag to indicate if this shutdown is occuring during
+            the TaskManager initialization
         relaxed :
             If `True` the function will wait for all active
             `CommandSequences` to finish before shutting down
@@ -434,17 +434,6 @@ class TaskManager:
         assert browser.browser_id is not None
         assert browser.curr_visit_id is not None
         reset = command_sequence.reset
-        if not reset:
-            self.logger.warning(
-                "BROWSER %i: Browser will not reset after CommandSequence "
-                "executes. OpenWPM does not currently support stateful crawls "
-                "(see: https://github.com/mozilla/OpenWPM/projects/2). "
-                "The next command issued to this browser may or may not "
-                "use the same profile (depending on the failure status of "
-                "this command). To prevent this warning, initialize the "
-                "CommandSequence with `reset` set to `True` to use a fresh "
-                "profile for each command." % browser.browser_id
-            )
         self.logger.info(
             "Starting to work on CommandSequence with "
             "visit_id %d on browser with id %d",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,11 +24,15 @@ EXTENSION_DIR = os.path.join(
 pytest_plugins = "test.storage.fixtures"
 
 
-@pytest.fixture(scope="session")
 def xpi():
     # Creates a new xpi using npm run build.
     print("Building new xpi")
     subprocess.check_call(["npm", "run", "build"], cwd=EXTENSION_DIR)
+
+
+@pytest.fixture(name="xpi", scope="session")
+def xpi_fixture():
+    return xpi()
 
 
 @pytest.fixture(scope="session")

--- a/test/test_callback.py
+++ b/test/test_callback.py
@@ -7,7 +7,7 @@ from .utilities import BASE_TEST_URL
 
 
 def test_local_callbacks(default_params, task_manager_creator):
-    """Test test the storage controller as well as the entire callback machinery
+    """Test the storage controller as well as the entire callback machinery
     to see if all callbacks get correctly called"""
     manager, _ = task_manager_creator(default_params)
     TEST_SITE = BASE_TEST_URL + "/test_pages/simple_a.html"

--- a/test/test_callback.py
+++ b/test/test_callback.py
@@ -17,7 +17,7 @@ def test_local_callbacks(default_params, task_manager_creator):
 
     my_list: List[int] = []
     sequence = CommandSequence(
-        TEST_SITE, reset=True, blocking=True, callback=partial(callback, my_list)
+        TEST_SITE, blocking=True, callback=partial(callback, my_list)
     )
     sequence.get()
 

--- a/test/test_crawl.py
+++ b/test/test_crawl.py
@@ -5,6 +5,7 @@ This should be avoided if possible, as controlled tests will be easier
 to debug.
 """
 
+import os
 import tarfile
 
 import domain_utils as du
@@ -41,6 +42,10 @@ def get_public_suffix(url):
     return url_parts[-1]
 
 
+@pytest.mark.skipif(
+    "CI" not in os.environ or os.environ["CI"] == "false",
+    reason="Makes remote connections",
+)
 @pytest.mark.slow
 def test_browser_profile_coverage(default_params, task_manager_creator):
     """Test the coverage of the browser's profile.

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -8,6 +8,8 @@ from openwpm.commands.types import BaseCommand
 from openwpm.errors import CommandExecutionError, ProfileLoadError
 from openwpm.utilities import db_utils
 
+from .utilities import BASE_TEST_URL
+
 # TODO update these tests to make use of blocking commands
 
 
@@ -18,7 +20,7 @@ def test_saving(default_params, task_manager_creator):
         manager_params.data_directory / "browser_profile"
     )
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
-    manager.get("http://example.com")
+    manager.get(BASE_TEST_URL)
     manager.close()
     assert (browser_params[0].profile_archive_dir / "profile.tar.gz").is_file()
 
@@ -32,7 +34,7 @@ def test_crash_profile(default_params, task_manager_creator):
     )
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
     try:
-        manager.get("http://example.com")  # So we have a profile
+        manager.get(BASE_TEST_URL)  # So we have a profile
         manager.get("example.com")  # Selenium requires scheme prefix
         manager.get("example.com")  # Selenium requires scheme prefix
         manager.get("example.com")  # Selenium requires scheme prefix
@@ -60,7 +62,7 @@ def test_profile_saved_when_launch_crashes(default_params, task_manager_creator)
     browser_params[0].proxy = True
     browser_params[0].save_content = "script"
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
-    manager.get("http://example.com")
+    manager.get(BASE_TEST_URL)
 
     # Kill the LevelDBAggregator
     # This will cause the proxy launch to crash
@@ -71,7 +73,7 @@ def test_profile_saved_when_launch_crashes(default_params, task_manager_creator)
 
     # The browser will fail to launch due to the proxy crashes
     try:
-        manager.get("http://example.com")
+        manager.get(BASE_TEST_URL)
     except CommandExecutionError:
         pass
     manager.close()
@@ -87,7 +89,7 @@ def test_seed_persistence(default_params, task_manager_creator):
 
     command_sequences = []
     for _ in range(2):
-        cs = CommandSequence(url="https://example.com")
+        cs = CommandSequence(url=BASE_TEST_URL)
         cs.get()
         cs.append_command(AssertConfigSetCommand("test_pref", True))
         command_sequences.append(cs)

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -87,7 +87,7 @@ def test_seed_persistance(default_params, task_manager_creator):
 
     command_sequences = []
     for _ in range(2):
-        cs = CommandSequence(url="https://example.com", reset=True)
+        cs = CommandSequence(url="https://example.com")
         cs.get()
         cs.append_command(AssertConfigSetCommand("test_pref", True))
         command_sequences.append(cs)

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -1,83 +1,81 @@
-from os.path import isfile, join
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 import pytest
 
 from openwpm.command_sequence import CommandSequence
 from openwpm.commands.types import BaseCommand
-from openwpm.config import BrowserParams, ManagerParams
 from openwpm.errors import CommandExecutionError, ProfileLoadError
-from openwpm.task_manager import TaskManager
 from openwpm.utilities import db_utils
-
-from .openwpmtest import OpenWPMTest
 
 # TODO update these tests to make use of blocking commands
 
 
-class TestProfile(OpenWPMTest):
-    def get_config(
-        self, data_dir: Optional[Path]
-    ) -> Tuple[ManagerParams, List[BrowserParams]]:
-        manager_params, browser_params = self.get_test_config(data_dir)
-        browser_params[0].profile_archive_dir = join(
-            manager_params.data_directory, "browser_profile"
-        )
-        return manager_params, browser_params
+def test_saving(default_params, task_manager_creator):
+    manager_params, browser_params = default_params
+    manager_params.num_browsers = 1
+    browser_params[0].profile_archive_dir = (
+        manager_params.data_directory / "browser_profile"
+    )
+    manager, _ = task_manager_creator((manager_params, browser_params[:1]))
+    manager.get("http://example.com")
+    manager.close()
+    assert (browser_params[0].profile_archive_dir / "profile.tar.gz").is_file()
 
-    @pytest.mark.xfail(run=False)
-    def test_saving(self):
-        manager_params, browser_params = self.get_config()
-        manager = TaskManager(manager_params, browser_params)
+
+def test_crash_profile(default_params, task_manager_creator):
+    manager_params, browser_params = default_params
+    manager_params.num_browsers = 1
+    manager_params.failure_limit = 2
+    browser_params[0].profile_archive_dir = (
+        manager_params.data_directory / "browser_profile"
+    )
+    manager, _ = task_manager_creator((manager_params, browser_params[:1]))
+    try:
+        manager.get("http://example.com")  # So we have a profile
+        manager.get("example.com")  # Selenium requires scheme prefix
+        manager.get("example.com")  # Selenium requires scheme prefix
+        manager.get("example.com")  # Selenium requires scheme prefix
+        manager.get("example.com")  # Requires two commands to shut down
+    except CommandExecutionError:
+        pass
+    assert (browser_params[0].profile_archive_dir / "profile.tar.gz").is_file()
+
+
+def test_profile_error(default_params, task_manager_creator):
+    manager_params, browser_params = default_params
+    manager_params.num_browsers = 1
+    browser_params[0].seed_tar = Path("/tmp/NOTREAL")
+    with pytest.raises(ProfileLoadError):
+        task_manager_creator((manager_params, browser_params[:1]))
+
+
+@pytest.mark.skip(reason="proxy no longer supported, need to update")
+def test_profile_saved_when_launch_crashes(default_params, task_manager_creator):
+    manager_params, browser_params = default_params
+    manager_params.num_browsers = 1
+    browser_params[0].profile_archive_dir = (
+        manager_params.data_directory / "browser_profile"
+    )
+    browser_params[0].proxy = True
+    browser_params[0].save_content = "script"
+    manager, _ = task_manager_creator((manager_params, browser_params[:1]))
+    manager.get("http://example.com")
+
+    # Kill the LevelDBAggregator
+    # This will cause the proxy launch to crash
+    manager.ldb_status_queue.put("DIE")
+    manager.browsers[0]._SPAWN_TIMEOUT = 2  # Have timeout occur quickly
+    manager.browsers[0]._UNSUCCESSFUL_SPAWN_LIMIT = 2  # Quick timeout
+    manager.get("example.com")  # Cause a selenium crash
+
+    # The browser will fail to launch due to the proxy crashes
+    try:
         manager.get("http://example.com")
-        manager.close()
-        assert isfile(join(browser_params[0].profile_archive_dir, "profile.tar.gz"))
-
-    @pytest.mark.xfail(run=False)
-    def test_crash_profile(self):
-        manager_params, browser_params = self.get_config()
-        manager_params.failure_limit = 2
-        manager = TaskManager(manager_params, browser_params)
-        try:
-            manager.get("http://example.com")  # So we have a profile
-            manager.get("example.com")  # Selenium requires scheme prefix
-            manager.get("example.com")  # Selenium requires scheme prefix
-            manager.get("example.com")  # Selenium requires scheme prefix
-            manager.get("example.com")  # Requires two commands to shut down
-        except CommandExecutionError:
-            pass
-        assert isfile(join(browser_params[0].profile_archive_dir, "profile.tar.gz"))
-
-    @pytest.mark.xfail(run=False)
-    def test_profile_error(self):
-        manager_params, browser_params = self.get_config()
-        browser_params[0].seed_tar = "/tmp/NOTREAL"
-        with pytest.raises(ProfileLoadError):
-            TaskManager(manager_params, browser_params)  # noqa
-
-    @pytest.mark.skip(reason="proxy no longer supported, need to update")
-    def test_profile_saved_when_launch_crashes(self):
-        manager_params, browser_params = self.get_config()
-        browser_params[0].proxy = True
-        browser_params[0].save_content = "script"
-        manager = TaskManager(manager_params, browser_params)
-        manager.get("http://example.com")
-
-        # Kill the LevelDBAggregator
-        # This will cause the proxy launch to crash
-        manager.ldb_status_queue.put("DIE")
-        manager.browsers[0]._SPAWN_TIMEOUT = 2  # Have timeout occur quickly
-        manager.browsers[0]._UNSUCCESSFUL_SPAWN_LIMIT = 2  # Quick timeout
-        manager.get("example.com")  # Cause a selenium crash
-
-        # The browser will fail to launch due to the proxy crashes
-        try:
-            manager.get("http://example.com")
-        except CommandExecutionError:
-            pass
-        manager.close()
-        assert isfile(join(browser_params[0].profile_archive_dir, "profile.tar.gz"))
+    except CommandExecutionError:
+        pass
+    manager.close()
+    assert (browser_params[0].profile_archive_dir / "profile.tar.gz").is_file()
 
 
 def test_seed_persistance(default_params, task_manager_creator):

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -78,7 +78,7 @@ def test_profile_saved_when_launch_crashes(default_params, task_manager_creator)
     assert (browser_params[0].profile_archive_dir / "profile.tar.gz").is_file()
 
 
-def test_seed_persistance(default_params, task_manager_creator):
+def test_seed_persistence(default_params, task_manager_creator):
     manager_params, browser_params = default_params
     p = Path("profile.tar.gz")
     for browser_param in browser_params:


### PR DESCRIPTION
This PR restores support for stateful crawling by addressing the core issue that broke it, i.e., the fact that geckodriver would delete the browser profile when closing or crashing before we had a chance to archive it. It does so by using a [custom profile](https://firefox-source-docs.mozilla.org/testing/geckodriver/CrashReports.html) instead of creating the profile via the `FirefoxProfile` Selenium class. The custom profile is set via the arguments of the `Options` class. 

**Note:**
Geckodriver has a bug that makes it write the browser preferences we set, as well as its own default browser preferences, to a `user.js` file in the wrong profile directory when using a custom profile: https://github.com/mozilla/geckodriver/issues/1844. As a temporary workaround until this issue gets fixed, we create the `user.js` file ourselves. In order to do this, we keep a copy of geckodriver's default preferences in `configure_firefox.py`.


This PR also:
* Fixes a bug in `PatchedGeckoDriverService` class that caused geckodriver not to receive the `service_args` passed when starting the browser.
* Removes the [code that intercepts the location of the browser profile from the geckodriver logs](https://github.com/mozilla/OpenWPM/blob/cb95ecc05fb4618e4275faecbc62b84123ebf1b0/openwpm/deploy_browsers/selenium_firefox.py#L71L74), as we no longer need it.
* Updates `manual_test.py`


Closes https://github.com/mozilla/OpenWPM/issues/423, Closes https://github.com/mozilla/OpenWPM/issues/383, Closes https://github.com/mozilla/OpenWPM/issues/161, Closes https://github.com/mozilla/OpenWPM/issues/253, Closes https://github.com/mozilla/OpenWPM/issues/384, Closes https://github.com/mozilla/OpenWPM/issues/680