### PR TITLE
Hotfixed GetCommand

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -30,7 +30,7 @@ dependencies:
 - selenium=3.141.0
 - sentry-sdk=0.20.3
 - tabulate=0.8.9
-- tblib=1.6.0
+- tblib=1.7.0
 - wget=1.20.1
 - pip:
   - dataclasses-json==0.5.2

--- a/openwpm/Extension/firefox/package-lock.json
+++ b/openwpm/Extension/firefox/package-lock.json
@@ -5783,14 +5783,12 @@
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-11.0.0.tgz",
           "integrity": "sha512-g01p1g4BmYlZ2+tdotCavrMunnPFPhTzG1ZiLKTCYrooHRbmvqo42ZZn4QMStUEIcn+jfLb6BRZX3JzIwA1ezQ==",
-          "dev": true,
           "optional": true
         },
         "@commitlint/load": {
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-11.0.0.tgz",
           "integrity": "sha512-t5ZBrtgvgCwPfxmG811FCp39/o3SJ7L+SNsxFL92OR4WQxPcu6c8taD0CG2lzOHGuRyuMxZ7ps3EbngT2WpiCg==",
-          "dev": true,
           "optional": true,
           "requires": {
             "@commitlint/execute-rule": "^11.0.0",
@@ -5806,7 +5804,6 @@
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-11.0.0.tgz",
           "integrity": "sha512-WinU6Uv6L7HDGLqn/To13KM1CWvZ09VHZqryqxXa1OY+EvJkfU734CwnOEeNlSCK7FVLrB4kmodLJtL1dkEpXw==",
-          "dev": true,
           "optional": true,
           "requires": {
             "import-fresh": "^3.0.0",
@@ -5819,7 +5816,6 @@
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-11.0.0.tgz",
           "integrity": "sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==",
-          "dev": true,
           "optional": true
         },
         "@concordance/react": {
@@ -5855,25 +5851,25 @@
           "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
         },
         "@nodelib/fs.scandir": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-          "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+          "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
           "requires": {
-            "@nodelib/fs.stat": "2.0.3",
+            "@nodelib/fs.stat": "2.0.4",
             "run-parallel": "^1.1.9"
           }
         },
         "@nodelib/fs.stat": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
         },
         "@nodelib/fs.walk": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-          "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+          "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
           "requires": {
-            "@nodelib/fs.scandir": "2.1.3",
+            "@nodelib/fs.scandir": "2.1.4",
             "fastq": "^1.6.0"
           }
         },
@@ -5937,7 +5933,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-          "dev": true,
           "optional": true
         },
         "JSONStream": {
@@ -5950,14 +5945,14 @@
           }
         },
         "acorn": {
-          "version": "8.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
-          "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ=="
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+          "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg=="
         },
         "acorn-walk": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.0.tgz",
-          "integrity": "sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA=="
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.2.tgz",
+          "integrity": "sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A=="
         },
         "add-stream": {
           "version": "1.0.0",
@@ -6156,19 +6151,19 @@
           "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "ava": {
-          "version": "3.13.0",
-          "resolved": "https://registry.npmjs.org/ava/-/ava-3.13.0.tgz",
-          "integrity": "sha512-yzky+gark5PdsFFlZ4CnBVxm/OgBUWtn9vAsSSnuooVJNOk5ER17HJXVeUzy63LIt06Zy34oThcn+2ZqgMs7SA==",
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/ava/-/ava-3.15.0.tgz",
+          "integrity": "sha512-HGAnk1SHPk4Sx6plFAUkzV/XC1j9+iQhOzt4vBly18/yo0AV8Oytx7mtJd/CR8igCJ5p160N/Oo/cNJi2uSeWA==",
           "requires": {
             "@concordance/react": "^2.0.0",
-            "acorn": "^8.0.1",
+            "acorn": "^8.0.4",
             "acorn-walk": "^8.0.0",
-            "ansi-styles": "^4.2.1",
+            "ansi-styles": "^5.0.0",
             "arrgv": "^1.0.2",
             "arrify": "^2.0.1",
             "callsites": "^3.1.0",
             "chalk": "^4.1.0",
-            "chokidar": "^3.4.2",
+            "chokidar": "^3.4.3",
             "chunkd": "^2.0.1",
             "ci-info": "^2.0.0",
             "ci-parallel-vars": "^1.0.1",
@@ -6180,9 +6175,9 @@
             "concordance": "^5.0.1",
             "convert-source-map": "^1.7.0",
             "currently-unhandled": "^0.4.1",
-            "debug": "^4.2.0",
+            "debug": "^4.3.1",
             "del": "^6.0.0",
-            "emittery": "^0.7.1",
+            "emittery": "^0.8.0",
             "equal-length": "^1.0.0",
             "figures": "^3.2.0",
             "globby": "^11.0.1",
@@ -6195,9 +6190,9 @@
             "lodash": "^4.17.20",
             "matcher": "^3.0.0",
             "md5-hex": "^3.0.1",
-            "mem": "^6.1.1",
-            "ms": "^2.1.2",
-            "ora": "^5.1.0",
+            "mem": "^8.0.0",
+            "ms": "^2.1.3",
+            "ora": "^5.2.0",
             "p-event": "^4.2.0",
             "p-map": "^4.0.0",
             "picomatch": "^2.2.2",
@@ -6208,14 +6203,41 @@
             "resolve-cwd": "^3.0.0",
             "slash": "^3.0.0",
             "source-map-support": "^0.5.19",
-            "stack-utils": "^2.0.2",
+            "stack-utils": "^2.0.3",
             "strip-ansi": "^6.0.0",
-            "supertap": "^1.0.0",
+            "supertap": "^2.0.0",
             "temp-dir": "^2.0.0",
             "trim-off-newlines": "^1.0.1",
-            "update-notifier": "^4.1.1",
+            "update-notifier": "^5.0.1",
             "write-file-atomic": "^3.0.3",
-            "yargs": "^16.0.3"
+            "yargs": "^16.2.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.1.0.tgz",
+              "integrity": "sha512-osxifZo3ar56+e8tdYreU6p8FZGciBHo5O0JoDAxMUqZuyNUb+yHEwYtJZ+Z32R459jEgtwVf1u8D7qYwU0l6w=="
+            },
+            "debug": {
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+              "requires": {
+                "ms": "2.1.2"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                  "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            }
           }
         },
         "balanced-match": {
@@ -6273,10 +6295,25 @@
             }
           }
         },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
         "binary-extensions": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+        },
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
         },
         "blueimp-md5": {
           "version": "2.18.0",
@@ -6284,33 +6321,29 @@
           "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
         },
         "boxen": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-          "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.0.tgz",
+          "integrity": "sha512-5bvsqw+hhgUi3oYGK0Vf4WpIkyemp60WBInn7+WNfoISzAqk/HX4L7WNROq38E6UR/y3YADpv6pEm4BfkeEAdA==",
           "requires": {
             "ansi-align": "^3.0.0",
-            "camelcase": "^5.3.1",
-            "chalk": "^3.0.0",
-            "cli-boxes": "^2.2.0",
-            "string-width": "^4.1.0",
-            "term-size": "^2.1.0",
-            "type-fest": "^0.8.1",
-            "widest-line": "^3.1.0"
+            "camelcase": "^6.2.0",
+            "chalk": "^4.1.0",
+            "cli-boxes": "^2.2.1",
+            "string-width": "^4.2.0",
+            "type-fest": "^0.20.2",
+            "widest-line": "^3.1.0",
+            "wrap-ansi": "^7.0.0"
           },
           "dependencies": {
-            "chalk": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
+            "camelcase": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+              "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
             },
             "type-fest": {
-              "version": "0.8.1",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+              "version": "0.20.2",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+              "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
             }
           }
         },
@@ -6329,6 +6362,15 @@
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "requires": {
             "fill-range": "^7.0.1"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "buffer-from": {
@@ -6389,8 +6431,7 @@
         "cachedir": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.2.0.tgz",
-          "integrity": "sha512-VvxA0xhNqIIfg0V9AmJkDg91DaJwryutH5rVEZAhcNi4iJFj9f+QxmAjgK1LT9I8OgToX27fypX6/MeCXVbBjQ==",
-          "dev": true
+          "integrity": "sha512-VvxA0xhNqIIfg0V9AmJkDg91DaJwryutH5rVEZAhcNi4iJFj9f+QxmAjgK1LT9I8OgToX27fypX6/MeCXVbBjQ=="
         },
         "caching-transform": {
           "version": "4.0.0",
@@ -6447,9 +6488,9 @@
           "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
         },
         "chokidar": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-          "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
@@ -6603,19 +6644,23 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+        },
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "commitizen": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.2.tgz",
-          "integrity": "sha512-uz+E6lGsDBDI2mYA4QfOxFeqdWUYwR1ky11YmLgg2BnEEP3YbeejpT4lxzGjkYqumnXr062qTOGavR9NtX/iwQ==",
-          "dev": true,
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.3.tgz",
+          "integrity": "sha512-pYlYEng7XMV2TW4xtjDKBGqeJ0Teq2zyRSx2S3Ml1XAplHSlJZK8vm1KdGclpMEZuGafbS5TeHXIVnHk8RWIzQ==",
           "requires": {
             "cachedir": "2.2.0",
-            "cz-conventional-changelog": "3.3.0",
+            "cz-conventional-changelog": "3.2.0",
             "dedent": "0.7.0",
             "detect-indent": "6.0.0",
             "find-node-modules": "2.0.0",
@@ -6630,11 +6675,55 @@
             "strip-json-comments": "3.0.1"
           },
           "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            },
+            "cz-conventional-changelog": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
+              "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+              "requires": {
+                "@commitlint/load": ">6.1.1",
+                "chalk": "^2.4.1",
+                "commitizen": "^4.0.3",
+                "conventional-commit-types": "^3.0.0",
+                "lodash.map": "^4.5.1",
+                "longest": "^2.0.1",
+                "word-wrap": "^1.0.3"
+              }
+            },
             "glob": {
               "version": "7.1.4",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
               "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-              "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -6644,17 +6733,28 @@
                 "path-is-absolute": "^1.0.0"
               }
             },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            },
             "strip-bom": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-              "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-              "dev": true
+              "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
             },
             "strip-json-comments": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-              "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-              "dev": true
+              "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
             }
           }
         },
@@ -6699,9 +6799,9 @@
           }
         },
         "concordance": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.1.tgz",
-          "integrity": "sha512-TbNtInKVElgEBnJ1v2Xg+MFX2lvFLbmlv3EuSC5wTfCwpB8kC3w3mffF6cKuUhkn475Ym1f1I4qmuXzx2+uXpw==",
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.2.tgz",
+          "integrity": "sha512-hC63FKdGM9tBcd4VQIa+LQjmrgorrnxESb8B3J21Qe/FzL0blBv0pb8iNyymt+bmsvGSUqO0uhPi2ZSLgLtLdg==",
           "requires": {
             "date-time": "^3.1.0",
             "esutils": "^2.0.3",
@@ -6727,20 +6827,20 @@
           }
         },
         "conventional-changelog": {
-          "version": "3.1.23",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.23.tgz",
-          "integrity": "sha512-sScUu2NHusjRC1dPc5p8/b3kT78OYr95/Bx7Vl8CPB8tF2mG1xei5iylDTRjONV5hTlzt+Cn/tBWrKdd299b7A==",
+          "version": "3.1.24",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.24.tgz",
+          "integrity": "sha512-ed6k8PO00UVvhExYohroVPXcOJ/K1N0/drJHx/faTH37OIZthlecuLIRX/T6uOp682CAoVoFpu+sSEaeuH6Asg==",
           "requires": {
-            "conventional-changelog-angular": "^5.0.11",
-            "conventional-changelog-atom": "^2.0.7",
-            "conventional-changelog-codemirror": "^2.0.7",
-            "conventional-changelog-conventionalcommits": "^4.4.0",
-            "conventional-changelog-core": "^4.2.0",
-            "conventional-changelog-ember": "^2.0.8",
-            "conventional-changelog-eslint": "^3.0.8",
-            "conventional-changelog-express": "^2.0.5",
-            "conventional-changelog-jquery": "^3.0.10",
-            "conventional-changelog-jshint": "^2.0.8",
+            "conventional-changelog-angular": "^5.0.12",
+            "conventional-changelog-atom": "^2.0.8",
+            "conventional-changelog-codemirror": "^2.0.8",
+            "conventional-changelog-conventionalcommits": "^4.5.0",
+            "conventional-changelog-core": "^4.2.1",
+            "conventional-changelog-ember": "^2.0.9",
+            "conventional-changelog-eslint": "^3.0.9",
+            "conventional-changelog-express": "^2.0.6",
+            "conventional-changelog-jquery": "^3.0.11",
+            "conventional-changelog-jshint": "^2.0.9",
             "conventional-changelog-preset-loader": "^2.3.4"
           }
         },
@@ -6775,9 +6875,9 @@
           "integrity": "sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ=="
         },
         "conventional-changelog-conventionalcommits": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.4.0.tgz",
-          "integrity": "sha512-ybvx76jTh08tpaYrYn/yd0uJNLt5yMrb1BphDe4WBredMlvPisvMghfpnJb6RmRNcqXeuhR6LfGZGewbkRm9yA==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.5.0.tgz",
+          "integrity": "sha512-buge9xDvjjOxJlyxUnar/+6i/aVEVGA7EEh4OafBCXPlLUQPGbRUBhBUveWRxzvR8TEjhKEP4BdepnpG2FSZXw==",
           "requires": {
             "compare-func": "^2.0.0",
             "lodash": "^4.17.15",
@@ -6785,16 +6885,16 @@
           }
         },
         "conventional-changelog-core": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.1.tgz",
-          "integrity": "sha512-8cH8/DEoD3e5Q6aeogdR5oaaKs0+mG6+f+Om0ZYt3PNv7Zo0sQhu4bMDRsqAF+UTekTAtP1W/C41jH/fkm8Jtw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.2.tgz",
+          "integrity": "sha512-7pDpRUiobQDNkwHyJG7k9f6maPo9tfPzkSWbRq97GGiZqisElhnvUZSvyQH20ogfOjntB5aadvv6NNcKL1sReg==",
           "requires": {
             "add-stream": "^1.0.0",
             "conventional-changelog-writer": "^4.0.18",
             "conventional-commits-parser": "^3.2.0",
             "dateformat": "^3.0.0",
             "get-pkg-repo": "^1.0.0",
-            "git-raw-commits": "2.0.0",
+            "git-raw-commits": "^2.0.8",
             "git-remote-origin-url": "^2.0.0",
             "git-semver-tags": "^4.1.1",
             "lodash": "^4.17.15",
@@ -6815,9 +6915,9 @@
               }
             },
             "hosted-git-info": {
-              "version": "3.0.7",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-              "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+              "integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
               "requires": {
                 "lru-cache": "^6.0.0"
               }
@@ -6851,11 +6951,11 @@
               }
             },
             "normalize-package-data": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-              "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+              "integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
               "requires": {
-                "hosted-git-info": "^3.0.6",
+                "hosted-git-info": "^4.0.0",
                 "resolve": "^1.17.0",
                 "semver": "^7.3.2",
                 "validate-npm-package-license": "^3.0.1"
@@ -6996,9 +7096,9 @@
           "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g=="
         },
         "conventional-changelog-writer": {
-          "version": "4.0.18",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.18.tgz",
-          "integrity": "sha512-mAQDCKyB9HsE8Ko5cCM1Jn1AWxXPYV0v8dFPabZRkvsiWUul2YyAqbIaoMKF88Zf2ffnOPSvKhboLf3fnjo5/A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
+          "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
           "requires": {
             "compare-func": "^2.0.0",
             "conventional-commits-filter": "^2.0.7",
@@ -7013,9 +7113,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "3.0.7",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-              "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+              "integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
               "requires": {
                 "lru-cache": "^6.0.0"
               }
@@ -7029,9 +7129,9 @@
               }
             },
             "meow": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-8.0.0.tgz",
-              "integrity": "sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==",
+              "version": "8.1.2",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+              "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
               "requires": {
                 "@types/minimist": "^1.2.0",
                 "camelcase-keys": "^6.2.2",
@@ -7047,20 +7147,23 @@
               }
             },
             "normalize-package-data": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-              "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+              "integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
               "requires": {
-                "hosted-git-info": "^3.0.6",
+                "hosted-git-info": "^4.0.0",
                 "resolve": "^1.17.0",
                 "semver": "^7.3.2",
                 "validate-npm-package-license": "^3.0.1"
               },
               "dependencies": {
                 "semver": {
-                  "version": "7.3.2",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-                  "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+                  "version": "7.3.4",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                  "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                  "requires": {
+                    "lru-cache": "^6.0.0"
+                  }
                 }
               }
             },
@@ -7084,8 +7187,7 @@
         "conventional-commit-types": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
-          "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
-          "dev": true
+          "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg=="
         },
         "conventional-commits-filter": {
           "version": "2.0.7",
@@ -7097,23 +7199,23 @@
           }
         },
         "conventional-commits-parser": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.0.tgz",
-          "integrity": "sha512-XmJiXPxsF0JhAKyfA2Nn+rZwYKJ60nanlbSWwwkGwLQFbugsc0gv1rzc7VbbUWAzJfR1qR87/pNgv9NgmxtBMQ==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
+          "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
           "requires": {
             "JSONStream": "^1.0.4",
             "is-text-path": "^1.0.1",
             "lodash": "^4.17.15",
             "meow": "^8.0.0",
-            "split2": "^2.0.0",
+            "split2": "^3.0.0",
             "through2": "^4.0.0",
             "trim-off-newlines": "^1.0.0"
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "3.0.7",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-              "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+              "integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
               "requires": {
                 "lru-cache": "^6.0.0"
               }
@@ -7127,9 +7229,9 @@
               }
             },
             "meow": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-8.0.0.tgz",
-              "integrity": "sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==",
+              "version": "8.1.2",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+              "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
               "requires": {
                 "@types/minimist": "^1.2.0",
                 "camelcase-keys": "^6.2.2",
@@ -7145,11 +7247,11 @@
               }
             },
             "normalize-package-data": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-              "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+              "integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
               "requires": {
-                "hosted-git-info": "^3.0.6",
+                "hosted-git-info": "^4.0.0",
                 "resolve": "^1.17.0",
                 "semver": "^7.3.2",
                 "validate-npm-package-license": "^3.0.1"
@@ -7168,51 +7270,74 @@
           }
         },
         "conventional-recommended-bump": {
-          "version": "6.0.10",
-          "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.0.10.tgz",
-          "integrity": "sha512-2ibrqAFMN3ZA369JgVoSbajdD/BHN6zjY7DZFKTHzyzuQejDUCjQ85S5KHxCRxNwsbDJhTPD5hOKcis/jQhRgg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.1.0.tgz",
+          "integrity": "sha512-uiApbSiNGM/kkdL9GTOLAqC4hbptObFo4wW2QRyHsKciGAfQuLU1ShZ1BIVI/+K2BE/W1AWYQMCXAsv4dyKPaw==",
           "requires": {
             "concat-stream": "^2.0.0",
             "conventional-changelog-preset-loader": "^2.3.4",
-            "conventional-commits-filter": "^2.0.6",
-            "conventional-commits-parser": "^3.1.0",
-            "git-raw-commits": "2.0.0",
-            "git-semver-tags": "^4.1.0",
-            "meow": "^7.0.0",
+            "conventional-commits-filter": "^2.0.7",
+            "conventional-commits-parser": "^3.2.0",
+            "git-raw-commits": "^2.0.8",
+            "git-semver-tags": "^4.1.1",
+            "meow": "^8.0.0",
             "q": "^1.5.1"
           },
           "dependencies": {
+            "hosted-git-info": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+              "integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
             "meow": {
-              "version": "7.1.1",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
-              "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
+              "version": "8.1.2",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+              "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
               "requires": {
                 "@types/minimist": "^1.2.0",
                 "camelcase-keys": "^6.2.2",
                 "decamelize-keys": "^1.1.0",
                 "hard-rejection": "^2.1.0",
                 "minimist-options": "4.1.0",
-                "normalize-package-data": "^2.5.0",
+                "normalize-package-data": "^3.0.0",
                 "read-pkg-up": "^7.0.1",
                 "redent": "^3.0.0",
                 "trim-newlines": "^3.0.0",
-                "type-fest": "^0.13.1",
-                "yargs-parser": "^18.1.3"
+                "type-fest": "^0.18.0",
+                "yargs-parser": "^20.2.3"
+              }
+            },
+            "normalize-package-data": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+              "integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
+              "requires": {
+                "hosted-git-info": "^4.0.0",
+                "resolve": "^1.17.0",
+                "semver": "^7.3.2",
+                "validate-npm-package-license": "^3.0.1"
               }
             },
             "type-fest": {
-              "version": "0.13.1",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-              "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+              "version": "0.18.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+              "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
             },
-            "yargs-parser": {
-              "version": "18.1.3",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
             }
           }
         },
@@ -7243,7 +7368,6 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
           "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
-          "dev": true,
           "optional": true,
           "requires": {
             "@types/parse-json": "^4.0.0",
@@ -7257,7 +7381,6 @@
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
               "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
-              "dev": true,
               "optional": true,
               "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -7352,7 +7475,6 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
           "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
-          "dev": true,
           "requires": {
             "@commitlint/load": ">6.1.1",
             "chalk": "^2.4.1",
@@ -7367,7 +7489,6 @@
               "version": "3.2.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "dev": true,
               "requires": {
                 "color-convert": "^1.9.0"
               }
@@ -7376,7 +7497,6 @@
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
               "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -7387,7 +7507,6 @@
               "version": "1.9.3",
               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
               "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-              "dev": true,
               "requires": {
                 "color-name": "1.1.3"
               }
@@ -7395,20 +7514,17 @@
             "color-name": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-              "dev": true
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
             },
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
               "version": "5.5.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
               "requires": {
                 "has-flag": "^3.0.0"
               }
@@ -7416,12 +7532,9 @@
           }
         },
         "dargs": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-          "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+          "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg=="
         },
         "date-time": {
           "version": "3.1.0",
@@ -7481,8 +7594,7 @@
         "dedent": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-          "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-          "dev": true
+          "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
         },
         "deep-extend": {
           "version": "0.6.0",
@@ -7580,8 +7692,7 @@
         "detect-file": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-          "dev": true
+          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
         },
         "detect-indent": {
           "version": "6.0.0",
@@ -7719,9 +7830,9 @@
           "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg=="
         },
         "emittery": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
-          "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ=="
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
+          "integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg=="
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -7880,7 +7991,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true,
           "requires": {
             "homedir-polyfill": "^1.0.1"
           }
@@ -7987,9 +8097,9 @@
           "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
         },
         "fast-glob": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
@@ -8000,9 +8110,9 @@
           }
         },
         "fastq": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
-          "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
+          "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
           "requires": {
             "reusify": "^1.0.4"
           }
@@ -8072,7 +8182,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.0.0.tgz",
           "integrity": "sha512-8MWIBRgJi/WpjjfVXumjPKCtmQ10B+fjx6zmSA+770GMJirLhWIzg8l763rhjl9xaeaHbnxPNRQKq2mgMhr+aw==",
-          "dev": true,
           "requires": {
             "findup-sync": "^3.0.0",
             "merge": "^1.2.1"
@@ -8081,8 +8190,7 @@
         "find-root": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-          "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-          "dev": true
+          "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
         },
         "find-up": {
           "version": "4.1.0",
@@ -8097,7 +8205,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
           "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-          "dev": true,
           "requires": {
             "detect-file": "^1.0.0",
             "is-glob": "^4.0.0",
@@ -8109,7 +8216,6 @@
               "version": "2.3.2",
               "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-              "dev": true,
               "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -8127,7 +8233,6 @@
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                  "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -8138,7 +8243,6 @@
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-              "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -8150,7 +8254,6 @@
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                  "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -8161,7 +8264,6 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -8170,7 +8272,6 @@
                   "version": "3.2.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -8181,7 +8282,6 @@
               "version": "3.1.10",
               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-              "dev": true,
               "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -8202,7 +8302,6 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
               "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-              "dev": true,
               "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
@@ -8583,212 +8682,71 @@
           }
         },
         "git-raw-commits": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
-          "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
+          "integrity": "sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==",
           "requires": {
-            "dargs": "^4.0.1",
-            "lodash.template": "^4.0.2",
-            "meow": "^4.0.0",
-            "split2": "^2.0.0",
-            "through2": "^2.0.0"
+            "dargs": "^7.0.0",
+            "lodash": "^4.17.15",
+            "meow": "^8.0.0",
+            "split2": "^3.0.0",
+            "through2": "^4.0.0"
           },
           "dependencies": {
-            "arrify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-            },
-            "camelcase": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-            },
-            "camelcase-keys": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-              "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-              "requires": {
-                "camelcase": "^4.1.0",
-                "map-obj": "^2.0.0",
-                "quick-lru": "^1.0.0"
-              }
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
-            },
-            "indent-string": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-              "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-            },
-            "load-json-file": {
+            "hosted-git-info": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+              "integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0",
-                "strip-bom": "^3.0.0"
+                "lru-cache": "^6.0.0"
               }
             },
-            "locate-path": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "lru-cache": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
               "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "yallist": "^4.0.0"
               }
-            },
-            "map-obj": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-              "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
             },
             "meow": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-              "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+              "version": "8.1.2",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+              "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
               "requires": {
-                "camelcase-keys": "^4.0.0",
-                "decamelize-keys": "^1.0.0",
-                "loud-rejection": "^1.0.0",
-                "minimist": "^1.1.3",
-                "minimist-options": "^3.0.1",
-                "normalize-package-data": "^2.3.4",
-                "read-pkg-up": "^3.0.0",
-                "redent": "^2.0.0",
-                "trim-newlines": "^2.0.0"
+                "@types/minimist": "^1.2.0",
+                "camelcase-keys": "^6.2.2",
+                "decamelize-keys": "^1.1.0",
+                "hard-rejection": "^2.1.0",
+                "minimist-options": "4.1.0",
+                "normalize-package-data": "^3.0.0",
+                "read-pkg-up": "^7.0.1",
+                "redent": "^3.0.0",
+                "trim-newlines": "^3.0.0",
+                "type-fest": "^0.18.0",
+                "yargs-parser": "^20.2.3"
               }
             },
-            "minimist-options": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-              "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+            "normalize-package-data": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+              "integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
               "requires": {
-                "arrify": "^1.0.1",
-                "is-plain-obj": "^1.1.0"
+                "hosted-git-info": "^4.0.0",
+                "resolve": "^1.17.0",
+                "semver": "^7.3.2",
+                "validate-npm-package-license": "^3.0.1"
               }
             },
-            "p-limit": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-              "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-              "requires": {
-                "p-try": "^1.0.0"
-              }
+            "type-fest": {
+              "version": "0.18.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+              "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
             },
-            "p-locate": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-              "requires": {
-                "p-limit": "^1.1.0"
-              }
-            },
-            "p-try": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            },
-            "path-type": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-              "requires": {
-                "pify": "^3.0.0"
-              }
-            },
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-            },
-            "quick-lru": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-              "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
-            },
-            "read-pkg": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-              "requires": {
-                "load-json-file": "^4.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-              "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-              "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "redent": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-              "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-              "requires": {
-                "indent-string": "^3.0.0",
-                "strip-indent": "^2.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "strip-indent": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-              "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
-            },
-            "through2": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-              "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
-              }
-            },
-            "trim-newlines": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-              "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
             }
           }
         },
@@ -8818,9 +8776,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "3.0.7",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-              "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+              "integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
               "requires": {
                 "lru-cache": "^6.0.0"
               }
@@ -8834,9 +8792,9 @@
               }
             },
             "meow": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-8.0.0.tgz",
-              "integrity": "sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==",
+              "version": "8.1.2",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+              "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
               "requires": {
                 "@types/minimist": "^1.2.0",
                 "camelcase-keys": "^6.2.2",
@@ -8852,20 +8810,23 @@
               }
             },
             "normalize-package-data": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-              "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+              "integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
               "requires": {
-                "hosted-git-info": "^3.0.6",
+                "hosted-git-info": "^4.0.0",
                 "resolve": "^1.17.0",
                 "semver": "^7.3.2",
                 "validate-npm-package-license": "^3.0.1"
               },
               "dependencies": {
                 "semver": {
-                  "version": "7.3.2",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-                  "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+                  "version": "7.3.4",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                  "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                  "requires": {
+                    "lru-cache": "^6.0.0"
+                  }
                 }
               }
             },
@@ -8889,7 +8850,10 @@
         "gitconfiglocal": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-          "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s="
+          "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+          "requires": {
+            "ini": "^1.3.2"
+          }
         },
         "glob": {
           "version": "7.1.6",
@@ -8913,15 +8877,24 @@
           }
         },
         "global-dirs": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-          "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+          "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+          "requires": {
+            "ini": "2.0.0"
+          },
+          "dependencies": {
+            "ini": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+              "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+            }
+          }
         },
         "global-modules": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-          "dev": true,
           "requires": {
             "global-prefix": "^1.0.1",
             "is-windows": "^1.0.1",
@@ -8932,10 +8905,10 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
           "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-          "dev": true,
           "requires": {
             "expand-tilde": "^2.0.2",
             "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
             "is-windows": "^1.0.1",
             "which": "^1.2.14"
           }
@@ -8946,9 +8919,9 @@
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "globby": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
+          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
           "requires": {
             "array-union": "^2.1.0",
             "dir-glob": "^3.0.1",
@@ -9099,16 +9072,10 @@
             }
           }
         },
-        "highlight.js": {
-          "version": "10.3.2",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.2.tgz",
-          "integrity": "sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw=="
-        },
         "homedir-polyfill": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-          "dev": true,
           "requires": {
             "parse-passwd": "^1.0.0"
           }
@@ -9216,7 +9183,6 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
           "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
-          "dev": true,
           "optional": true,
           "requires": {
             "parent-module": "^1.0.0",
@@ -9227,7 +9193,6 @@
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
               "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-              "dev": true,
               "optional": true
             }
           }
@@ -9270,11 +9235,15 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+        },
         "inquirer": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
           "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
-          "dev": true,
           "requires": {
             "ansi-escapes": "^3.2.0",
             "chalk": "^2.4.2",
@@ -9294,14 +9263,12 @@
             "ansi-regex": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "ansi-styles": {
               "version": "3.2.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "dev": true,
               "requires": {
                 "color-convert": "^1.9.0"
               }
@@ -9310,7 +9277,6 @@
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
               "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -9321,7 +9287,6 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
               "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-              "dev": true,
               "requires": {
                 "restore-cursor": "^2.0.0"
               }
@@ -9330,7 +9295,6 @@
               "version": "1.9.3",
               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
               "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-              "dev": true,
               "requires": {
                 "color-name": "1.1.3"
               }
@@ -9338,14 +9302,12 @@
             "color-name": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-              "dev": true
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
             },
             "figures": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
               "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-              "dev": true,
               "requires": {
                 "escape-string-regexp": "^1.0.5"
               }
@@ -9353,32 +9315,22 @@
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "mimic-fn": {
               "version": "1.2.0",
               "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-              "dev": true
-            },
-            "mute-stream": {
-              "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-              "dev": true
+              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
             },
             "onetime": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
               "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-              "dev": true,
               "requires": {
                 "mimic-fn": "^1.0.0"
               }
@@ -9387,7 +9339,6 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
               "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-              "dev": true,
               "requires": {
                 "onetime": "^2.0.0",
                 "signal-exit": "^3.0.2"
@@ -9397,7 +9348,6 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
@@ -9407,7 +9357,6 @@
                   "version": "4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                   "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                  "dev": true,
                   "requires": {
                     "ansi-regex": "^3.0.0"
                   }
@@ -9418,7 +9367,6 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
               },
@@ -9426,8 +9374,7 @@
                 "ansi-regex": {
                   "version": "4.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                  "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                  "dev": true
+                  "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
                 }
               }
             },
@@ -9435,7 +9382,6 @@
               "version": "5.5.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
               "requires": {
                 "has-flag": "^3.0.0"
               }
@@ -9588,12 +9534,12 @@
           }
         },
         "is-installed-globally": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-          "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+          "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
           "requires": {
-            "global-dirs": "^2.0.1",
-            "is-path-inside": "^3.0.1"
+            "global-dirs": "^3.0.0",
+            "is-path-inside": "^3.0.2"
           }
         },
         "is-interactive": {
@@ -9607,9 +9553,9 @@
           "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
         },
         "is-npm": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-          "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig=="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+          "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA=="
         },
         "is-number": {
           "version": "7.0.0",
@@ -9954,11 +9900,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
           "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
-        "lodash._reinterpolate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-        },
         "lodash.flattendeep": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -9972,25 +9913,7 @@
         "lodash.map": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-          "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
-          "dev": true
-        },
-        "lodash.template": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-          "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-          "requires": {
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.templatesettings": "^4.0.0"
-          }
-        },
-        "lodash.templatesettings": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-          "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-          "requires": {
-            "lodash._reinterpolate": "^3.0.0"
-          }
+          "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
         },
         "lodash.toarray": {
           "version": "4.4.0",
@@ -10046,8 +9969,7 @@
         "longest": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
-          "integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g=",
-          "dev": true
+          "integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g="
         },
         "loud-rejection": {
           "version": "1.6.0",
@@ -10119,9 +10041,9 @@
           }
         },
         "marked": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.4.tgz",
-          "integrity": "sha512-6x5TFGCTKSQBLTZtOburGxCxFEBJEGYVLwCMTBCxzvyuisGcC20UNzDSJhCr/cJ/Kmh6ulfJm10g6WWEAJ3kvg=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+          "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw=="
         },
         "matcher": {
           "version": "3.0.0",
@@ -10147,12 +10069,12 @@
           }
         },
         "mem": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.1.tgz",
-          "integrity": "sha512-Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-8.0.0.tgz",
+          "integrity": "sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==",
           "requires": {
             "map-age-cleaner": "^0.1.3",
-            "mimic-fn": "^3.0.0"
+            "mimic-fn": "^3.1.0"
           },
           "dependencies": {
             "mimic-fn": {
@@ -10204,8 +10126,7 @@
         "merge": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-          "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-          "dev": true
+          "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
         },
         "merge2": {
           "version": "1.4.1",
@@ -10351,9 +10272,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mute-stream": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
         "nanomatch": {
           "version": "1.2.13",
@@ -10553,11 +10474,6 @@
           "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
           "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0="
         },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
         "nyc": {
           "version": "15.1.0",
           "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
@@ -10740,6 +10656,29 @@
             "mimic-fn": "^2.1.0"
           }
         },
+        "onigasm": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+          "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+          "requires": {
+            "lru-cache": "^5.1.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+            }
+          }
+        },
         "open": {
           "version": "7.3.0",
           "resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
@@ -10762,16 +10701,16 @@
           }
         },
         "ora": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-5.1.0.tgz",
-          "integrity": "sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+          "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
           "requires": {
+            "bl": "^4.0.3",
             "chalk": "^4.1.0",
             "cli-cursor": "^3.1.0",
-            "cli-spinners": "^2.4.0",
+            "cli-spinners": "^2.5.0",
             "is-interactive": "^1.0.0",
             "log-symbols": "^4.0.0",
-            "mute-stream": "0.0.8",
             "strip-ansi": "^6.0.0",
             "wcwidth": "^1.0.1"
           }
@@ -10893,7 +10832,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
           "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-          "dev": true,
           "optional": true,
           "requires": {
             "callsites": "^3.0.0"
@@ -10921,8 +10859,7 @@
         "parse-passwd": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-          "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-          "dev": true
+          "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -11055,9 +10992,9 @@
           "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
         },
         "prettier": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-          "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg=="
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+          "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q=="
         },
         "pretty-ms": {
           "version": "7.0.1",
@@ -11395,6 +11332,11 @@
             "strict-uri-encode": "^1.0.0"
           }
         },
+        "queue-microtask": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+          "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
+        },
         "quick-lru": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -11406,6 +11348,7 @@
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
             "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
           }
@@ -11578,7 +11521,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-          "dev": true,
           "requires": {
             "expand-tilde": "^2.0.0",
             "global-modules": "^1.0.0"
@@ -11593,7 +11535,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
           "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
-          "dev": true,
           "optional": true,
           "requires": {
             "global-dirs": "^0.1.1"
@@ -11603,8 +11544,10 @@
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
               "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-              "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "ini": "^1.3.4"
+              }
             }
           }
         },
@@ -11654,9 +11597,12 @@
           "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
         },
         "run-parallel": {
-          "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-          "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+          "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+          "requires": {
+            "queue-microtask": "^1.2.2"
+          }
         },
         "rxjs": {
           "version": "6.6.3",
@@ -11705,9 +11651,19 @@
           }
         },
         "serialize-error": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-          "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+          "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+          "requires": {
+            "type-fest": "^0.13.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.13.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+              "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+            }
+          }
         },
         "set-blocking": {
           "version": "2.0.0",
@@ -11769,6 +11725,15 @@
             "glob": "^7.0.0",
             "interpret": "^1.0.0",
             "rechoir": "^0.6.2"
+          }
+        },
+        "shiki": {
+          "version": "0.9.3",
+          "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
+          "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
+          "requires": {
+            "onigasm": "^2.2.5",
+            "vscode-textmate": "^5.2.0"
           }
         },
         "signal-exit": {
@@ -12013,44 +11978,11 @@
           }
         },
         "split2": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-          "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
           "requires": {
-            "through2": "^2.0.2"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "through2": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-              "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
-              }
-            }
+            "readable-stream": "^3.0.0"
           }
         },
         "sprintf-js": {
@@ -12074,11 +12006,14 @@
           }
         },
         "standard-version": {
-          "version": "github:conventional-changelog/standard-version#0a801d9ddb88941158271073190e2d5eb2bc67d0",
-          "from": "github:conventional-changelog/standard-version#master",
+          "version": "git+ssh://git@github.com/conventional-changelog/standard-version.git#0a801d9ddb88941158271073190e2d5eb2bc67d0",
+          "from": "standard-version@github:conventional-changelog/standard-version#master",
           "requires": {
             "chalk": "^2.4.2",
+            "conventional-changelog": "3.1.24",
             "conventional-changelog-config-spec": "2.1.0",
+            "conventional-changelog-conventionalcommits": "4.5.0",
+            "conventional-recommended-bump": "6.1.0",
             "detect-indent": "^6.0.0",
             "detect-newline": "^3.1.0",
             "dotgitignore": "^2.1.0",
@@ -12087,7 +12022,8 @@
             "fs-access": "^1.0.1",
             "git-semver-tags": "^4.0.0",
             "semver": "^7.1.1",
-            "stringify-package": "^1.0.1"
+            "stringify-package": "^1.0.1",
+            "yargs": "^16.0.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -12106,16 +12042,6 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
-              }
-            },
-            "cliui": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-              "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-              "requires": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^6.2.0"
               }
             },
             "color-convert": {
@@ -12154,11 +12080,11 @@
               }
             },
             "p-limit": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
-              "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+              "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
               "requires": {
-                "p-try": "^2.0.0"
+                "yocto-queue": "^0.1.0"
               }
             },
             "p-locate": {
@@ -12175,106 +12101,6 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
                 "has-flag": "^3.0.0"
-              }
-            },
-            "wrap-ansi": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-              "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-              "requires": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "4.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                  "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                  "requires": {
-                    "color-convert": "^2.0.1"
-                  }
-                },
-                "color-convert": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                  "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                  "requires": {
-                    "color-name": "~1.1.4"
-                  }
-                },
-                "color-name": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                  "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                }
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-            },
-            "yargs": {
-              "version": "15.4.1",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-              "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-              "requires": {
-                "cliui": "^6.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^4.1.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^4.2.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.2"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                  "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                  "requires": {
-                    "locate-path": "^5.0.0",
-                    "path-exists": "^4.0.0"
-                  }
-                },
-                "locate-path": {
-                  "version": "5.0.0",
-                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                  "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-                  "requires": {
-                    "p-locate": "^4.1.0"
-                  }
-                },
-                "p-limit": {
-                  "version": "2.3.0",
-                  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                  "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-                  "requires": {
-                    "p-try": "^2.0.0"
-                  }
-                },
-                "p-locate": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                  "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                  "requires": {
-                    "p-limit": "^2.2.0"
-                  }
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "18.1.3",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
               }
             }
           }
@@ -12470,40 +12296,15 @@
           "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
         },
         "supertap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
-          "integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supertap/-/supertap-2.0.0.tgz",
+          "integrity": "sha512-jRzcXlCeDYvKoZGA5oRhYyR3jUIYu0enkSxtmAgHRlD7HwrovTpH4bDSi0py9FtuA8si9cW/fKommJHuaoDHJA==",
           "requires": {
-            "arrify": "^1.0.1",
-            "indent-string": "^3.2.0",
-            "js-yaml": "^3.10.0",
-            "serialize-error": "^2.1.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-            },
-            "indent-string": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-              "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
+            "arrify": "^2.0.1",
+            "indent-string": "^4.0.0",
+            "js-yaml": "^3.14.0",
+            "serialize-error": "^7.0.1",
+            "strip-ansi": "^6.0.0"
           }
         },
         "supports-color": {
@@ -12549,11 +12350,6 @@
               "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
             }
           }
-        },
-        "term-size": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-          "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="
         },
         "test-exclude": {
           "version": "6.0.0",
@@ -13025,32 +12821,44 @@
           }
         },
         "typedoc": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
-          "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+          "version": "0.20.32",
+          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.32.tgz",
+          "integrity": "sha512-GSopd/tiqoKE3fEdvhoaEpR9yrEPsR9tknAjkoeSPL6p1Rq5aVsKxBhhF6cwoDJ7oWjpvnm8vs0rQN0BxEHuWQ==",
           "requires": {
-            "fs-extra": "^9.0.1",
-            "handlebars": "^4.7.6",
-            "highlight.js": "^10.2.0",
-            "lodash": "^4.17.20",
+            "colors": "^1.4.0",
+            "fs-extra": "^9.1.0",
+            "handlebars": "^4.7.7",
+            "lodash": "^4.17.21",
             "lunr": "^2.3.9",
-            "marked": "^1.1.1",
+            "marked": "^2.0.1",
             "minimatch": "^3.0.0",
             "progress": "^2.0.3",
-            "semver": "^7.3.2",
             "shelljs": "^0.8.4",
-            "typedoc-default-themes": "^0.11.4"
+            "shiki": "^0.9.3",
+            "typedoc-default-themes": "^0.12.9"
           },
           "dependencies": {
             "fs-extra": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-              "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+              "version": "9.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
               "requires": {
                 "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
-                "universalify": "^1.0.0"
+                "universalify": "^2.0.0"
+              }
+            },
+            "handlebars": {
+              "version": "4.7.7",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+              "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+              "requires": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
               }
             },
             "jsonfile": {
@@ -13060,31 +12868,29 @@
               "requires": {
                 "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
-              },
-              "dependencies": {
-                "universalify": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-                  "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-                }
               }
             },
+            "lodash": {
+              "version": "4.17.21",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            },
             "universalify": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-              "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
             }
           }
         },
         "typedoc-default-themes": {
-          "version": "0.11.4",
-          "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-          "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw=="
+          "version": "0.12.9",
+          "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.9.tgz",
+          "integrity": "sha512-Jd5fYTiqzinZdoIY382W7tQXTwAzWRdg8KbHfaxmb78m1/3jL9riXtk23oBOKwhi8GFVykCOdPzEJKY87/D0LQ=="
         },
         "typescript": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-          "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ=="
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
         },
         "uglify-js": {
           "version": "3.11.6",
@@ -13153,33 +12959,46 @@
           }
         },
         "update-notifier": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
-          "integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+          "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
           "requires": {
-            "boxen": "^4.2.0",
-            "chalk": "^3.0.0",
+            "boxen": "^5.0.0",
+            "chalk": "^4.1.0",
             "configstore": "^5.0.1",
             "has-yarn": "^2.1.0",
             "import-lazy": "^2.1.0",
             "is-ci": "^2.0.0",
-            "is-installed-globally": "^0.3.1",
-            "is-npm": "^4.0.0",
+            "is-installed-globally": "^0.4.0",
+            "is-npm": "^5.0.0",
             "is-yarn-global": "^0.3.0",
-            "latest-version": "^5.0.0",
-            "pupa": "^2.0.1",
+            "latest-version": "^5.1.0",
+            "pupa": "^2.1.1",
+            "semver": "^7.3.4",
             "semver-diff": "^3.1.1",
             "xdg-basedir": "^4.0.0"
           },
           "dependencies": {
-            "chalk": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "lru-cache": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
               "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
+                "yallist": "^4.0.0"
               }
+            },
+            "semver": {
+              "version": "7.3.4",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+              "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
             }
           }
         },
@@ -13233,6 +13052,11 @@
             "spdx-expression-parse": "^3.0.0"
           }
         },
+        "vscode-textmate": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+          "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+        },
         "wcwidth": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -13270,8 +13094,7 @@
         "word-wrap": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-          "dev": true
+          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -13355,13 +13178,12 @@
           "version": "1.10.0",
           "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
           "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-          "dev": true,
           "optional": true
         },
         "yargs": {
-          "version": "16.1.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.1.tgz",
-          "integrity": "sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==",
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",
@@ -13373,9 +13195,14 @@
           }
         },
         "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+          "version": "20.2.5",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
+          "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg=="
+        },
+        "yocto-queue": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
         }
       }
     },

--- a/openwpm/Extension/webext-instrumentation/package-lock.json
+++ b/openwpm/Extension/webext-instrumentation/package-lock.json
@@ -7310,8 +7310,8 @@
       }
     },
     "standard-version": {
-      "version": "github:conventional-changelog/standard-version#0a801d9ddb88941158271073190e2d5eb2bc67d0",
-      "from": "github:conventional-changelog/standard-version#master",
+      "version": "git+ssh://git@github.com/conventional-changelog/standard-version.git#0a801d9ddb88941158271073190e2d5eb2bc67d0",
+      "from": "standard-version@github:conventional-changelog/standard-version#master",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -15,10 +15,14 @@ from selenium.common.exceptions import (
     TimeoutException,
     WebDriverException,
 )
+from selenium.webdriver import Firefox
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
+# Constants for bot mitigation
+from ..config import BrowserParams, ManagerParams
+from ..socket_interface import ClientSocket
 from .types import BaseCommand
 from .utils.webdriver_utils import (
     execute_in_all_frames,
@@ -28,8 +32,6 @@ from .utils.webdriver_utils import (
     scroll_down,
     wait_until_loaded,
 )
-
-# Constants for bot mitigation
 
 NUM_MOUSE_MOVES = 10  # Times to randomly move the mouse
 RANDOM_SLEEP_LOW = 1  # low (in sec) for random sleep between page loads
@@ -125,11 +127,11 @@ class GetCommand(BaseCommand):
 
     def execute(
         self,
-        webdriver,
-        browser_params,
-        manager_params,
-        extension_socket,
-    ):
+        webdriver: Firefox,
+        browser_params: BrowserParams,
+        manager_params: ManagerParams,
+        extension_socket: ClientSocket,
+    ) -> None:
         tab_restart_browser(webdriver)
 
         if extension_socket is not None:
@@ -147,7 +149,7 @@ class GetCommand(BaseCommand):
         # Close modal dialog if exists
         try:
             WebDriverWait(webdriver, 0.5).until(EC.alert_is_present())
-            alert = webdriver.switch_to.alert()
+            alert = webdriver.switch_to.alert
             alert.dismiss()
             time.sleep(1)
         except (TimeoutException, WebDriverException):

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -20,7 +20,6 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-# Constants for bot mitigation
 from ..config import BrowserParams, ManagerParams
 from ..socket_interface import ClientSocket
 from .types import BaseCommand
@@ -33,6 +32,7 @@ from .utils.webdriver_utils import (
     wait_until_loaded,
 )
 
+# Constants for bot mitigation
 NUM_MOUSE_MOVES = 10  # Times to randomly move the mouse
 RANDOM_SLEEP_LOW = 1  # low (in sec) for random sleep between page loads
 RANDOM_SLEEP_HIGH = 7  # high (in sec) for random sleep between page loads


### PR DESCRIPTION
`webdriver.switch_to.alert` unlike most other variants of the `switch_to` API is not a function but a property.
This led to `TypeError:'Alert' object is not callable` when there was actually an `Alert` to switch to.
This PR fixes that behaviour. 