### PR TITLE
Remove python to js string

### DIFF
--- a/openwpm/Extension/firefox/feature.js/index.js
+++ b/openwpm/Extension/firefox/feature.js/index.js
@@ -21,7 +21,7 @@ async function main() {
       navigation_instrument:true,
       cookie_instrument:true,
       js_instrument:true,
-      js_instrument_settings: `
+      cleaned_js_instrument_settings:
       [
         {
           object: window.CanvasRenderingContext2D.prototype,
@@ -29,7 +29,6 @@ async function main() {
           logSettings: {
             propertiesToInstrument: [],
             nonExistingPropertiesToInstrument: [],
-            excludedProperties: [],
             excludedProperties: [],
             logCallStack: false,
             logFunctionsAsStrings: false,
@@ -39,7 +38,7 @@ async function main() {
             depth: 5,
           }
         },
-      ]`,
+      ],
       http_instrument:true,
       callstack_instrument:true,
       save_content:false,
@@ -70,7 +69,7 @@ async function main() {
     loggingDB.logDebug("Javascript instrumentation enabled");
     let jsInstrument = new JavascriptInstrument(loggingDB);
     jsInstrument.run(config['browser_id']);
-    await jsInstrument.registerContentScript(config['testing'], config['js_instrument_settings']);
+    await jsInstrument.registerContentScript(config['testing'], config['cleaned_js_instrument_settings']);
   }
 
   if (config['http_instrument']) {

--- a/openwpm/Extension/firefox/feature.js/index.js
+++ b/openwpm/Extension/firefox/feature.js/index.js
@@ -24,7 +24,7 @@ async function main() {
       cleaned_js_instrument_settings:
       [
         {
-          object: window.CanvasRenderingContext2D.prototype,
+          object: `window.CanvasRenderingContext2D.prototype`,
           instrumentedName: "CanvasRenderingContext2D",
           logSettings: {
             propertiesToInstrument: [],

--- a/openwpm/Extension/firefox/feature.js/loggingdb.js
+++ b/openwpm/Extension/firefox/feature.js/loggingdb.js
@@ -44,7 +44,7 @@ let listeningSocketCallback =  async (data) => {
 
 }
 export let open = async function(storageControllerAddress, logAddress, curr_crawlID) {
-    if (storageControllerAddress == null && logAddress == null && curr_crawlID === '') {
+    if (storageControllerAddress == null && logAddress == null && curr_crawlID === 0) {
         console.log("Debugging, everything will output to console");
         debugging = true;
         return;

--- a/openwpm/Extension/webext-instrumentation/src/background/javascript-instrument.ts
+++ b/openwpm/Extension/webext-instrumentation/src/background/javascript-instrument.ts
@@ -111,11 +111,11 @@ export class JavascriptInstrument {
 
   public async registerContentScript(
     testing: boolean,
-    jsInstrumentationSettingsString: string,
+    jsInstrumentationSettings: object,
   ) {
     const contentScriptConfig = {
       testing,
-      jsInstrumentationSettingsString,
+      jsInstrumentationSettings,
     };
     if (contentScriptConfig) {
       // TODO: Avoid using window to pass the content script config

--- a/openwpm/Extension/webext-instrumentation/src/content/javascript-instrument-content-scope.ts
+++ b/openwpm/Extension/webext-instrumentation/src/content/javascript-instrument-content-scope.ts
@@ -2,7 +2,7 @@ import {getInstrumentJS} from "../lib/js-instruments";
 import {pageScript} from "./javascript-instrument-page-scope";
 
 function getPageScriptAsString(
-  jsInstrumentationSettingsString: string,
+  jsInstrumentationSettingsString: object,
 ): string {
   // The JS Instrument Requests are setup and validated python side
   // including setting defaults for logSettings. See JSInstrumentation.py
@@ -63,7 +63,7 @@ document.addEventListener(eventId, function(e: CustomEvent) {
 
 export function injectJavascriptInstrumentPageScript(contentScriptConfig) {
   insertScript(
-    getPageScriptAsString(contentScriptConfig.jsInstrumentationSettingsString),
+    getPageScriptAsString(contentScriptConfig.jsInstrumentationSettings),
     eventId,
     contentScriptConfig.testing,
   );

--- a/openwpm/Extension/webext-instrumentation/src/content/javascript-instrument-content-scope.ts
+++ b/openwpm/Extension/webext-instrumentation/src/content/javascript-instrument-content-scope.ts
@@ -2,7 +2,7 @@ import {getInstrumentJS} from "../lib/js-instruments";
 import {pageScript} from "./javascript-instrument-page-scope";
 
 function getPageScriptAsString(
-  jsInstrumentationSettingsString: object,
+  jsInstrumentationSettings: object,
 ): string {
   // The JS Instrument Requests are setup and validated python side
   // including setting defaults for logSettings. See JSInstrumentation.py
@@ -12,7 +12,7 @@ ${getInstrumentJS}
 // End of js-instruments.
 
 // Start of custom instrumentRequests.
-const jsInstrumentationSettings = ${JSON.stringify(jsInstrumentationSettingsString)};
+const jsInstrumentationSettings = ${JSON.stringify(jsInstrumentationSettings)};
 // End of custom instrumentRequests.
 
 // Start of anonymous function from javascript-instrument-page-scope.ts

--- a/openwpm/Extension/webext-instrumentation/src/content/javascript-instrument-content-scope.ts
+++ b/openwpm/Extension/webext-instrumentation/src/content/javascript-instrument-content-scope.ts
@@ -12,7 +12,7 @@ ${getInstrumentJS}
 // End of js-instruments.
 
 // Start of custom instrumentRequests.
-const jsInstrumentationSettings = ${jsInstrumentationSettingsString};
+const jsInstrumentationSettings = ${JSON.stringify(jsInstrumentationSettingsString)};
 // End of custom instrumentRequests.
 
 // Start of anonymous function from javascript-instrument-page-scope.ts

--- a/openwpm/Extension/webext-instrumentation/src/lib/js-instruments.ts
+++ b/openwpm/Extension/webext-instrumentation/src/lib/js-instruments.ts
@@ -767,7 +767,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     // More details about how this function is invoked are in
     // content/javascript-instrument-content-scope.ts
     JSInstrumentRequests.forEach(function(item) {
-      instrumentObject(item.object, item.instrumentedName, item.logSettings);
+      instrumentObject(eval(item.object), item.instrumentedName, item.logSettings);
     });
   }
 

--- a/openwpm/Extension/webext-instrumentation/src/lib/js-instruments.ts
+++ b/openwpm/Extension/webext-instrumentation/src/lib/js-instruments.ts
@@ -14,7 +14,7 @@ interface LogSettings {
 }
 
 interface JSInstrumentRequest {
-  object: string;
+  object: any;
   instrumentedName: string;
   logSettings: LogSettings;
 }

--- a/openwpm/Extension/webext-instrumentation/src/lib/js-instruments.ts
+++ b/openwpm/Extension/webext-instrumentation/src/lib/js-instruments.ts
@@ -14,7 +14,7 @@ interface LogSettings {
 }
 
 interface JSInstrumentRequest {
-  object: any;
+  object: string;
   instrumentedName: string;
   logSettings: LogSettings;
 }

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -2,7 +2,7 @@ import os
 from dataclasses import dataclass, field
 from json import JSONEncoder
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from dataclasses_json import DataClassJsonMixin
 from dataclasses_json import config as DCJConfig
@@ -146,6 +146,7 @@ class ManagerParams(DataClassJsonMixin):
 class BrowserParamsInternal(BrowserParams):
     browser_id: Optional[BrowserId] = None
     profile_path: Optional[Path] = None
+    cleaned_js_instrument_settings: Optional[List[Dict[str, Any]]] = None
 
 
 @dataclass

--- a/openwpm/js_instrumentation.py
+++ b/openwpm/js_instrumentation.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Any, Dict, List
 
 import jsonschema
 
@@ -18,23 +19,6 @@ shortcut_specs = {
         curdir, "js_instrumentation_collections", "fingerprinting.json"
     )
 }
-
-
-def _python_to_js_string(py_in):
-    """Takes python in and converts it to a string
-    of the equivalent JS object.
-
-    Customized for our specific needs:
-    * expects a list
-    * object is de-quoted
-    """
-    objects = [x["object"] for x in py_in]
-    out = json.dumps(py_in)
-    for o in objects:
-        obj_str_before = f'"object": "{o}",'
-        obj_str_after = f'"object": {o},'
-        out = out.replace(obj_str_before, obj_str_after)
-    return out
 
 
 def _validate(python_list_to_validate):
@@ -136,8 +120,6 @@ def _build_full_settings_object(setting):
         propertiesToInstrument property of a new LogSettings object.
     We must also create the instrumentedName value.
     """
-    obj = None
-    instrumentedName = None
     logSettings = get_default_log_settings()
 
     if isinstance(setting, str):
@@ -207,7 +189,9 @@ def get_default_log_settings():
     }
 
 
-def clean_js_instrumentation_settings(user_requested_settings):
+def clean_js_instrumentation_settings(
+    user_requested_settings: List[Any],
+) -> List[Dict[str, Any]]:
     """Convert user input JSinstrumentation settings to full settings object.
 
     Accepts a list. From the list we need to parse each item.
@@ -260,4 +244,4 @@ def clean_js_instrumentation_settings(user_requested_settings):
             settings.append(_build_full_settings_object(setting))
     settings = _merge_settings(settings)
     _validate(settings)
-    return _python_to_js_string(settings)
+    return settings

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import pickle
-import sys
 import threading
 import time
 import traceback
@@ -18,9 +17,7 @@ from openwpm.config import (
     BrowserParamsInternal,
     ManagerParams,
     ManagerParamsInternal,
-    validate_browser_params,
     validate_crawl_configs,
-    validate_manager_params,
 )
 
 from .browser_manager import Browser
@@ -115,7 +112,7 @@ class TaskManager:
         for a_browsers_params in self.browser_params:
             js_settings = a_browsers_params.js_instrument_settings
             cleaned_js_settings = clean_js_instrumentation_settings(js_settings)
-            a_browsers_params.js_instrument_settings = cleaned_js_settings
+            a_browsers_params.cleaned_js_instrument_settings = cleaned_js_settings
 
         # Flow control
         self.closing = False

--- a/openwpm/utilities/platform_utils.py
+++ b/openwpm/utilities/platform_utils.py
@@ -125,7 +125,7 @@ def get_configuration_string(manager_params, browser_params, versions):
         # Separate out long profile directory strings
         profile_dirs[browser_id] = str(item.pop("seed_tar"))
         archive_dirs[browser_id] = str(item.pop("profile_archive_dir"))
-        js_config[browser_id] = item.pop("js_instrument_settings")
+        js_config[browser_id] = item.pop("cleaned_js_instrument_settings")
 
         # Copy items in sorted order
         dct = OrderedDict()


### PR DESCRIPTION
We now pass along a Dict/JS object for as long as possible, only serialize it to valid JSON and eval at the last reasonable location.
Closes #857 