### PR TITLE
Moved _issue_command to BrowserManagerHandle

### DIFF
--- a/docs/Platform-Architecture.md
+++ b/docs/Platform-Architecture.md
@@ -22,7 +22,7 @@ In OpenWPM we have a watchdog thread that tries to ensure two things.
 ## Issuing commands
 
 OpenWPM uses the `CommandSequence` as a fundamental unit of work.
-A `CommandSequence` describes as series of steps that will execute in order on a particular Browser.
+A `CommandSequence` describes as series of steps that will execute in order on a particular browser.
 All available Commands are visible by inspecting the `CommandSequence` API.
 
 For example you could wire up a `CommandSequence` to go to a given url and take a screenshot of it by writing:
@@ -57,17 +57,26 @@ Have a look at [`custom_command.py`](../custom_command.py)
 
 Contained in `openwpm/BrowserManager.py`, Browser Managers provide a wrapper around the drivers used to automate full browser instances. In particular, we opted to use [Selenium](http://docs.seleniumhq.org/) to drive full browser instances as bot detection frameworks can more easily detect lightweight alternatives such as PhantomJS. 
 
-Browser Managers receive commands from the Task Manager, which they then pass to the command executor (located in `openwpm/commands/command_executor.py`), which receives a command object and converts it into web driver actions. Browser Managers also receive browser parameters which they use to instantiate the Selenium web driver using one of the browser initialization functions contained in `openwpm/deploy_browsers`.
+Browser Managers receive the commands in a CommandSequence from the Task Manager one by one, calling the `execute`
+method on each of them and stopping if one command should fail.
+Browser Managers also receive browser parameters which they use to instantiate the Selenium web driver using one of
+the browser initialization functions contained in `openwpm/deploy_browsers`.
 
-The Browser class, contained in the same file, is the Task Manager's wrapper around Browser Managers, which allow it to cleanly kill and restart Browser Managers as necessary.
+The BrowserManagerHandle class, contained in the same file, is the Task Manager's wrapper around Browser Managers,
+which allow it to cleanly kill and restart Browser Managers as necessary.
 
-**Important Programming Note** The Browser Managers are designed to isolate the Task Manager from the underlying browser instances. As part of this approach, no data from the browsers should flow up to the Task Manager (beyond basic metadata such as the browsers' process IDs). For instance, if the Browser Manager is assigned the task of collecting and parsing XPath data, this parsing should be completed by Browser Managers and **not** passed up to the Task Manager for post-processing.
+**Important Programming Note** The Browser Managers are designed to isolate the Task Manager from the underlying browser
+instances. As part of this approach, no data from the browsers should flow up to the Task Manager
+(beyond basic metadata such as the browsers' process IDs). For instance, if the Browser Manager is assigned the task of
+collecting and parsing XPath data, this parsing should be completed by Browser Managers
+and **not** passed up to the Task Manager for post-processing.
 
 ## Browser Information Logging
 
 Throughout the course of a measurement, the Browser Managers' commands (along with timestamps and the status of the commands)
 are logged by the Task Manager, which contributes to the reproducibility of individual experiments.
-The data is sent to the Storage Controller process, which provides stability in logging data despite the possibility of individual browser crashes.
+The data is sent to the Storage Controller process,
+which provides stability in logging data despite the possibility of individual browser crashes.
 
 # The WebExtension
 

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -1,4 +1,5 @@
 import errno
+import json
 import logging
 import os
 import pickle
@@ -11,19 +12,25 @@ import time
 import traceback
 from pathlib import Path
 from queue import Empty as EmptyQueue
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import psutil
+import tblib
 from multiprocess import Queue
 from selenium.common.exceptions import WebDriverException
 from tblib import pickling_support
 
+from .command_sequence import CommandSequence
+from .commands.browser_commands import FinalizeCommand
 from .commands.profile_commands import dump_profile
 from .commands.types import BaseCommand, ShutdownSignal
+from .commands.utils.webdriver_utils import parse_neterror
 from .config import BrowserParamsInternal, ManagerParamsInternal
 from .deploy_browsers import deploy_firefox
 from .errors import BrowserConfigError, BrowserCrashError, ProfileLoadError
 from .socket_interface import ClientSocket
+from .storage.storage_providers import TableName
+from .task_manager import TaskManager
 from .types import BrowserId, VisitId
 from .utilities.multiprocess_utils import (
     Process,
@@ -327,6 +334,184 @@ class BrowserManagerHandle:
         self.logger.debug(
             "BROWSER %i: Browser manager closed successfully." % self.browser_id
         )
+
+    def execute_command_sequence(
+        self, tm: TaskManager, command_sequence: CommandSequence
+    ) -> None:
+        """
+        Sends CommandSequence to the BrowserManager one command at a time
+        """
+        assert self.browser_id is not None
+        assert self.curr_visit_id is not None
+        tm.sock.store_record(
+            TableName("site_visits"),
+            self.curr_visit_id,
+            {
+                "visit_id": self.curr_visit_id,
+                "browser_id": self.browser_id,
+                "site_url": command_sequence.url,
+                "site_rank": command_sequence.site_rank,
+            },
+        )
+        self.is_fresh = False
+
+        reset = command_sequence.reset
+        self.logger.info(
+            "Starting to work on CommandSequence with "
+            "visit_id %d on browser with id %d",
+            self.curr_visit_id,
+            self.browser_id,
+        )
+        assert self.command_queue is not None
+        assert self.status_queue is not None
+
+        for command_and_timeout in command_sequence.get_commands_with_timeout():
+            command, timeout = command_and_timeout
+            command.set_visit_browser_id(self.curr_visit_id, self.browser_id)
+            command.set_start_time(time.time())
+            self.current_timeout = timeout
+
+            # Adding timer to track performance of commands
+            t1 = time.time_ns()
+
+            # passes off command and waits for a success (or failure signal)
+            self.command_queue.put(command)
+
+            # received reply from BrowserManager, either success or failure
+            error_text = None
+            tb = None
+            status = None
+            try:
+                status = self.status_queue.get(True, self.current_timeout)
+            except EmptyQueue:
+                self.logger.info(
+                    "BROWSER %i: Timeout while executing command, %s, killing "
+                    "browser manager" % (self.browser_id, repr(command))
+                )
+
+            if status is None:
+                # allows us to skip this entire block without having to bloat
+                # every if statement
+                command_status = "timeout"
+                pass
+            elif status == "OK":
+                command_status = "ok"
+            elif status[0] == "CRITICAL":
+                command_status = "critical"
+                self.logger.critical(
+                    "BROWSER %i: Received critical error from browser "
+                    "process while executing command %s. Setting failure "
+                    "status." % (self.browser_id, str(command))
+                )
+                self.failure_status = {
+                    "ErrorType": "CriticalChildException",
+                    "CommandSequence": command_sequence,
+                    "Exception": status[1],
+                }
+                error_text, tb = self._unpack_pickled_error(status[1])
+            elif status[0] == "FAILED":
+                command_status = "error"
+                error_text, tb = self._unpack_pickled_error(status[1])
+                self.logger.info(
+                    "BROWSER %i: Received failure status while executing "
+                    "command: %s" % (self.browser_id, repr(command))
+                )
+            elif status[0] == "NETERROR":
+                command_status = "neterror"
+                error_text, tb = self._unpack_pickled_error(status[1])
+                error_text = parse_neterror(error_text)
+                self.logger.info(
+                    "BROWSER %i: Received neterror %s while executing "
+                    "command: %s" % (self.browser_id, error_text, repr(command))
+                )
+            else:
+                raise ValueError("Unknown browser status message %s" % status)
+
+            tm.sock.store_record(
+                TableName("crawl_history"),
+                self.curr_visit_id,
+                {
+                    "browser_id": self.browser_id,
+                    "visit_id": self.curr_visit_id,
+                    "command": type(command).__name__,
+                    "arguments": json.dumps(
+                        command.__dict__, default=lambda x: repr(x)
+                    ).encode("utf-8"),
+                    "retry_number": command_sequence.retry_number,
+                    "command_status": command_status,
+                    "error": error_text,
+                    "traceback": tb,
+                    "duration": int((time.time_ns() - t1) / 1000000),
+                },
+            )
+
+            if command_status == "critical":
+                tm.sock.finalize_visit_id(
+                    success=False,
+                    visit_id=self.curr_visit_id,
+                )
+                return
+
+            if command_status != "ok":
+                with tm.threadlock:
+                    tm.failure_count += 1
+                if tm.failure_count > tm.failure_limit:
+                    self.logger.critical(
+                        "BROWSER %i: Command execution failure pushes failure "
+                        "count above the allowable limit. Setting "
+                        "failure_status." % self.browser_id
+                    )
+                    self.failure_status = {
+                        "ErrorType": "ExceedCommandFailureLimit",
+                        "CommandSequence": command_sequence,
+                    }
+                    return
+                self.restart_required = True
+                self.logger.debug(
+                    "BROWSER %i: Browser restart required" % self.browser_id
+                )
+            # Reset failure_count at the end of each successful command sequence
+            elif type(command) is FinalizeCommand:
+                with tm.threadlock:
+                    tm.failure_count = 0
+
+            if self.restart_required:
+                tm.sock.finalize_visit_id(success=False, visit_id=self.curr_visit_id)
+                break
+
+        self.logger.info(
+            "Finished working on CommandSequence with "
+            "visit_id %d on browser with id %d",
+            self.curr_visit_id,
+            self.browser_id,
+        )
+        # Sleep after executing CommandSequence to provide extra time for
+        # internal buffers to drain. Stopgap in support of #135
+        time.sleep(2)
+
+        if tm.closing:
+            return
+
+        if self.restart_required or reset:
+            success = self.restart_browser_manager(clear_profile=reset)
+            if not success:
+                self.logger.critical(
+                    "BROWSER %i: Exceeded the maximum allowable consecutive "
+                    "browser launch failures. Setting failure_status." % self.browser_id
+                )
+                tm.failure_status = {
+                    "ErrorType": "ExceedLaunchFailureLimit",
+                    "CommandSequence": command_sequence,
+                }
+                return
+            self.restart_required = False
+
+    def _unpack_pickled_error(self, pickled_error: bytes) -> Tuple[str, str]:
+        """Unpacks `pickled_error` into an error `message` and `tb` string."""
+        exc = pickle.loads(pickled_error)
+        message = traceback.format_exception(*exc)[-1]
+        tb = json.dumps(tblib.Traceback(exc[2]).to_dict())
+        return message, tb
 
     def kill_browser_manager(self):
         """Kill the BrowserManager process and all of its children"""

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -18,7 +18,6 @@ import psutil
 import tblib
 from multiprocess import Queue
 from selenium.common.exceptions import WebDriverException
-from tblib import pickling_support
 
 from .command_sequence import CommandSequence
 from .commands.browser_commands import FinalizeCommand
@@ -41,7 +40,7 @@ from .utilities.multiprocess_utils import (
     parse_traceback_for_sentry,
 )
 
-pickling_support.install()
+tblib.pickling_support.install()
 
 
 class BrowserManagerHandle:
@@ -340,7 +339,8 @@ class BrowserManagerHandle:
 
     def execute_command_sequence(
         self,
-        tm: "TaskManager",  # Quoting to break cyclic import, see https://stackoverflow.com/a/39757388
+        # Quoting to break cyclic import, see https://stackoverflow.com/a/39757388
+        tm: "TaskManager", 
         command_sequence: CommandSequence,
     ) -> None:
         """
@@ -408,7 +408,7 @@ class BrowserManagerHandle:
                     "process while executing command %s. Setting failure "
                     "status." % (self.browser_id, str(command))
                 )
-                self.failure_status = {
+                tm.failure_status = {
                     "ErrorType": "CriticalChildException",
                     "CommandSequence": command_sequence,
                     "Exception": status[1],
@@ -466,7 +466,7 @@ class BrowserManagerHandle:
                         "count above the allowable limit. Setting "
                         "failure_status." % self.browser_id
                     )
-                    self.failure_status = {
+                    tm.failure_status = {
                         "ErrorType": "ExceedCommandFailureLimit",
                         "CommandSequence": command_sequence,
                     }

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -34,7 +34,7 @@ from .utilities.multiprocess_utils import (
 pickling_support.install()
 
 
-class Browser:
+class BrowserManagerHandle:
     """
     The Browser class is responsible for holding all of the
     configuration and status information on BrowserManager process

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -12,7 +12,7 @@ import time
 import traceback
 from pathlib import Path
 from queue import Empty as EmptyQueue
-from typing import Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import psutil
 import tblib
@@ -30,7 +30,10 @@ from .deploy_browsers import deploy_firefox
 from .errors import BrowserConfigError, BrowserCrashError, ProfileLoadError
 from .socket_interface import ClientSocket
 from .storage.storage_providers import TableName
-from .task_manager import TaskManager
+
+if TYPE_CHECKING:
+    from .task_manager import TaskManager
+
 from .types import BrowserId, VisitId
 from .utilities.multiprocess_utils import (
     Process,
@@ -43,7 +46,7 @@ pickling_support.install()
 
 class BrowserManagerHandle:
     """
-    The Browser class is responsible for holding all of the
+    The BrowserManagerHandle class is responsible for holding all of the
     configuration and status information on BrowserManager process
     it corresponds to. It also includes a set of methods for managing
     the BrowserManager process and its child processes/threads.
@@ -336,7 +339,9 @@ class BrowserManagerHandle:
         )
 
     def execute_command_sequence(
-        self, tm: TaskManager, command_sequence: CommandSequence
+        self,
+        tm: "TaskManager",  # Quoting to break cyclic import, see https://stackoverflow.com/a/39757388
+        command_sequence: CommandSequence,
     ) -> None:
         """
         Sends CommandSequence to the BrowserManager one command at a time

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -1,13 +1,10 @@
-import json
 import logging
 import os
 import pickle
 import threading
 import time
-import traceback
-from queue import Empty as EmptyQueue
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Set, Tuple, Type
+from typing import Any, Dict, List, Optional, Set, Type
 
 import psutil
 import tblib
@@ -22,15 +19,12 @@ from openwpm.config import (
 
 from .browser_manager import BrowserManagerHandle
 from .command_sequence import CommandSequence
-from .commands.browser_commands import FinalizeCommand
-from .commands.utils.webdriver_utils import parse_neterror
 from .errors import CommandExecutionError
 from .js_instrumentation import clean_js_instrumentation_settings
 from .mp_logger import MPLogger
 from .storage.storage_controller import DataSocket, StorageControllerHandle
 from .storage.storage_providers import (
     StructuredStorageProvider,
-    TableName,
     UnstructuredStorageProvider,
 )
 from .utilities.multiprocess_utils import kill_process_and_children
@@ -377,20 +371,9 @@ class TaskManager:
         if command_sequence.callback:
             self.unsaved_command_sequences[visit_id] = command_sequence
 
-        self.sock.store_record(
-            TableName("site_visits"),
-            visit_id,
-            {
-                "visit_id": visit_id,
-                "browser_id": browser.browser_id,
-                "site_url": command_sequence.url,
-                "site_rank": command_sequence.site_rank,
-            },
-        )
-
         # Start command execution thread
-        args = (browser, command_sequence)
-        thread = threading.Thread(target=self._issue_command, args=args)
+        args = (self, command_sequence)
+        thread = threading.Thread(target=browser.execute_command_sequence, args=args)
         browser.command_thread = thread
         thread.daemon = True
         thread.start()
@@ -415,176 +398,6 @@ class TaskManager:
                 cs = self.unsaved_command_sequences.pop(visit_id, None)
                 if cs:
                     cs.mark_done(successful)
-
-    def _unpack_pickled_error(self, pickled_error: bytes) -> Tuple[str, str]:
-        """Unpacks `pickled_error` into an error `message` and `tb` string."""
-        exc = pickle.loads(pickled_error)
-        message = traceback.format_exception(*exc)[-1]
-        tb = json.dumps(tblib.Traceback(exc[2]).to_dict())
-        return message, tb
-
-    def _issue_command(
-        self, browser: BrowserManagerHandle, command_sequence: CommandSequence
-    ) -> None:
-        """
-        Sends CommandSequence to the BrowserManager one command at a time
-        """
-        browser.is_fresh = False
-        assert browser.browser_id is not None
-        assert browser.curr_visit_id is not None
-        reset = command_sequence.reset
-        self.logger.info(
-            "Starting to work on CommandSequence with "
-            "visit_id %d on browser with id %d",
-            browser.curr_visit_id,
-            browser.browser_id,
-        )
-        assert browser.command_queue is not None
-        assert browser.status_queue is not None
-
-        for command_and_timeout in command_sequence.get_commands_with_timeout():
-            command, timeout = command_and_timeout
-            command.set_visit_browser_id(browser.curr_visit_id, browser.browser_id)
-            command.set_start_time(time.time())
-            browser.current_timeout = timeout
-
-            # Adding timer to track performance of commands
-            t1 = time.time_ns()
-
-            # passes off command and waits for a success (or failure signal)
-            browser.command_queue.put(command)
-
-            # received reply from BrowserManager, either success or failure
-            error_text = None
-            tb = None
-            status = None
-            try:
-                status = browser.status_queue.get(True, browser.current_timeout)
-            except EmptyQueue:
-                self.logger.info(
-                    "BROWSER %i: Timeout while executing command, %s, killing "
-                    "browser manager" % (browser.browser_id, repr(command))
-                )
-
-            if status is None:
-                # allows us to skip this entire block without having to bloat
-                # every if statement
-                command_status = "timeout"
-                pass
-            elif status == "OK":
-                command_status = "ok"
-            elif status[0] == "CRITICAL":
-                command_status = "critical"
-                self.logger.critical(
-                    "BROWSER %i: Received critical error from browser "
-                    "process while executing command %s. Setting failure "
-                    "status." % (browser.browser_id, str(command))
-                )
-                self.failure_status = {
-                    "ErrorType": "CriticalChildException",
-                    "CommandSequence": command_sequence,
-                    "Exception": status[1],
-                }
-                error_text, tb = self._unpack_pickled_error(status[1])
-            elif status[0] == "FAILED":
-                command_status = "error"
-                error_text, tb = self._unpack_pickled_error(status[1])
-                self.logger.info(
-                    "BROWSER %i: Received failure status while executing "
-                    "command: %s" % (browser.browser_id, repr(command))
-                )
-            elif status[0] == "NETERROR":
-                command_status = "neterror"
-                error_text, tb = self._unpack_pickled_error(status[1])
-                error_text = parse_neterror(error_text)
-                self.logger.info(
-                    "BROWSER %i: Received neterror %s while executing "
-                    "command: %s" % (browser.browser_id, error_text, repr(command))
-                )
-            else:
-                raise ValueError("Unknown browser status message %s" % status)
-
-            self.sock.store_record(
-                TableName("crawl_history"),
-                browser.curr_visit_id,
-                {
-                    "browser_id": browser.browser_id,
-                    "visit_id": browser.curr_visit_id,
-                    "command": type(command).__name__,
-                    "arguments": json.dumps(
-                        command.__dict__, default=lambda x: repr(x)
-                    ).encode("utf-8"),
-                    "retry_number": command_sequence.retry_number,
-                    "command_status": command_status,
-                    "error": error_text,
-                    "traceback": tb,
-                    "duration": int((time.time_ns() - t1) / 1000000),
-                },
-            )
-
-            if command_status == "critical":
-                self.sock.finalize_visit_id(
-                    success=False,
-                    visit_id=browser.curr_visit_id,
-                )
-                return
-
-            if command_status != "ok":
-                with self.threadlock:
-                    self.failure_count += 1
-                if self.failure_count > self.failure_limit:
-                    self.logger.critical(
-                        "BROWSER %i: Command execution failure pushes failure "
-                        "count above the allowable limit. Setting "
-                        "failure_status." % browser.browser_id
-                    )
-                    self.failure_status = {
-                        "ErrorType": "ExceedCommandFailureLimit",
-                        "CommandSequence": command_sequence,
-                    }
-                    return
-                browser.restart_required = True
-                self.logger.debug(
-                    "BROWSER %i: Browser restart required" % (browser.browser_id)
-                )
-            # Reset failure_count at the end of each successful command sequence
-            elif type(command) is FinalizeCommand:
-                with self.threadlock:
-                    self.failure_count = 0
-
-            if browser.restart_required:
-                self.sock.finalize_visit_id(
-                    success=False, visit_id=browser.curr_visit_id
-                )
-                break
-
-        self.logger.info(
-            "Finished working on CommandSequence with "
-            "visit_id %d on browser with id %d",
-            browser.curr_visit_id,
-            browser.browser_id,
-        )
-        # Sleep after executing CommandSequence to provide extra time for
-        # internal buffers to drain. Stopgap in support of #135
-        time.sleep(2)
-
-        if self.closing:
-            return
-
-        if browser.restart_required or reset:
-            success = browser.restart_browser_manager(clear_profile=reset)
-            if not success:
-                self.logger.critical(
-                    "BROWSER %i: Exceeded the maximum allowable consecutive "
-                    "browser launch failures. Setting failure_status."
-                    % (browser.browser_id)
-                )
-                self.failure_status = {
-                    "ErrorType": "ExceedLaunchFailureLimit",
-                    "CommandSequence": command_sequence,
-                }
-                return
-            browser.restart_required = False
 
     def execute_command_sequence(
         self, command_sequence: CommandSequence, index: Optional[int] = None

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -20,7 +20,7 @@ from openwpm.config import (
     validate_crawl_configs,
 )
 
-from .browser_manager import Browser
+from .browser_manager import BrowserManagerHandle
 from .command_sequence import CommandSequence
 from .commands.browser_commands import FinalizeCommand
 from .commands.utils.webdriver_utils import parse_neterror
@@ -181,14 +181,16 @@ class TaskManager:
 
     def _initialize_browsers(
         self, browser_params: List[BrowserParamsInternal]
-    ) -> List[Browser]:
+    ) -> List[BrowserManagerHandle]:
         """ initialize the browser classes, each its unique set of params """
         browsers = list()
         for i in range(self.num_browsers):
             browser_params[
                 i
             ].browser_id = self.storage_controller_handle.get_next_browser_id()
-            browsers.append(Browser(self.manager_params, browser_params[i]))
+            browsers.append(
+                BrowserManagerHandle(self.manager_params, browser_params[i])
+            )
 
         return browsers
 
@@ -361,7 +363,7 @@ class TaskManager:
     # CRAWLER COMMAND CODE
 
     def _start_thread(
-        self, browser: Browser, command_sequence: CommandSequence
+        self, browser: BrowserManagerHandle, command_sequence: CommandSequence
     ) -> threading.Thread:
         """  starts the command execution thread """
 
@@ -422,7 +424,7 @@ class TaskManager:
         return message, tb
 
     def _issue_command(
-        self, browser: Browser, command_sequence: CommandSequence
+        self, browser: BrowserManagerHandle, command_sequence: CommandSequence
     ) -> None:
         """
         Sends CommandSequence to the BrowserManager one command at a time


### PR DESCRIPTION
This piece of code conceptually belongs to the BrowserManagerHandle, so I moved it there.
However I couldn't think of an easy way to remove all references to the TaskManager so for now we still pass the TaskManager as a parameter.