### PR TITLE
Introduced delay in BrowserManager

### DIFF
--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -661,6 +661,8 @@ def BrowserManager(
             )
             extension_socket = ClientSocket(serialization="json")
             extension_socket.connect("127.0.0.1", int(port))
+            # Gives the extension additional time to start up (see issue #892)
+            time.sleep(5)
         else:
             extension_socket = None
 


### PR DESCRIPTION
This PR is a quick-fix response to #892
By delaying the startup of a browser if we have the extension enabled, the extension should be able to fully start up before we start executing commands.

@bkrumnow could you please test this change and let me know if it resolves the issue?