### PR TITLE
Generate module index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
-docs/source/
+docs/apidoc/
 
 # npm packages
 node_modules

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 
 # Dependencies to be installed using conda package manager
 conda:
-  environment: environment-rtd.yaml
+  environment: docs/environment-rtd.yaml
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,10 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
+from sphinx.ext import apidoc
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, project_root)
 
 
 # -- Project information -----------------------------------------------------
@@ -67,3 +70,14 @@ html_theme = "alabaster"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ["_static"]
+
+
+# Auto-generate API documentation
+# Source: https://github.com/readthedocs/readthedocs.org/issues/1139
+def run_apidoc(_):
+    output_path = os.path.join(project_root, "docs", "apidoc")
+    module_path = os.path.join(project_root, "openwpm")
+    apidoc.main(["-o", output_path, module_path, "--separate", "--force"])
+
+def setup(app):
+    app.connect("builder-inited", run_apidoc)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,9 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
+
+# type: ignore
+
 import os
 import sys
 
@@ -78,6 +80,7 @@ def run_apidoc(_):
     output_path = os.path.join(project_root, "docs", "apidoc")
     module_path = os.path.join(project_root, "openwpm")
     apidoc.main(["-o", output_path, module_path, "--separate", "--force"])
+
 
 def setup(app):
     app.connect("builder-inited", run_apidoc)

--- a/docs/environment-rtd.yaml
+++ b/docs/environment-rtd.yaml
@@ -1,0 +1,43 @@
+channels:
+- conda-forge
+- main
+dependencies:
+- beautifulsoup4=4.9.3
+- black=20.8b1
+- click=7.1.2
+- codecov=2.1.11
+- dill=0.3.3
+- gcsfs=0.8.0
+- geckodriver=0.26.0
+- ipython=7.22.0
+- leveldb=1.23
+- multiprocess=0.70.11.1
+- mypy=0.812
+- nodejs=14.15.4
+- pandas=1.2.4
+- pillow=8.1.2
+- pip=21.0.1
+- pre-commit=2.12.1
+- psutil=5.8.0
+- pyarrow=3.0.0
+- pytest-asyncio=0.14.0
+- pytest-cov=2.11.1
+- pytest=6.2.3
+- python=3.9.2
+- pyvirtualdisplay=2.1
+- recommonmark=0.7.1
+- redis-py=3.5.3
+- s3fs=0.6.0
+- selenium=3.141.0
+- sentry-sdk=0.20.3
+- sphinx-markdown-tables=0.0.15
+- sphinx=3.5.4
+- tabulate=0.8.9
+- tblib=1.7.0
+- wget=1.20.1
+- pip:
+  - dataclasses-json==0.5.2
+  - domain-utils==0.7.1
+  - jsonschema==3.2.0
+  - plyvel==1.3.0
+name: openwpm

--- a/environment-rtd.yaml
+++ b/environment-rtd.yaml
@@ -1,8 +1,0 @@
-channels:
-- conda-forge
-- main
-dependencies:
-- recommonmark=0.7.1
-- sphinx-markdown-tables=0.0.15
-- sphinx=3.5.4
-name: openwpm

--- a/scripts/prune-environment.py
+++ b/scripts/prune-environment.py
@@ -78,3 +78,12 @@ env_pinned.pop("prefix")
 
 with open("../environment.yaml", "w") as f:
     f.write(yaml.dump(env_pinned))
+
+
+for i, pinned_dep in enumerate(env_pinned["dependencies"]):
+    if pinned_dep.split("=")[0] == "geckodriver":
+        env_pinned["dependencies"][i] = "geckodriver=0.26.0"
+        break
+
+with open("../docs/environment-rtd.yaml", "w") as f:
+    f.write(yaml.dump(env_pinned))

--- a/scripts/prune-environment.py
+++ b/scripts/prune-environment.py
@@ -79,7 +79,7 @@ env_pinned.pop("prefix")
 with open("../environment.yaml", "w") as f:
     f.write(yaml.dump(env_pinned))
 
-
+# See https://github.com/mozilla/OpenWPM/issues/890
 for i, pinned_dep in enumerate(env_pinned["dependencies"]):
     if pinned_dep.split("=")[0] == "geckodriver":
         env_pinned["dependencies"][i] = "geckodriver=0.26.0"


### PR DESCRIPTION
This PR fixes https://github.com/mozilla/OpenWPM/issues/895 by setting up Sphinx to automatically run `sphinx-apidoc` for every build, using the workaround suggested in https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-312626491. Also, it moves readthedocs dependencies under `docs/` and makes `prune-environment.py` automatically generate the `environment-rtd.yaml` file whenever we run `repin.sh`, so that we don't have to remember to keep it in sync with the main `environment.yaml` manually.

Note that we have to install all dependencies and not just the ones required to build the docs after all, as `autodoc` [imports the modules](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc) in order to extract the docstrings. Not installing all dependencies would result in import errors.

@vringar, could you please point me to where you found the conda version that readthedocs uses, that you mentioned in https://github.com/mozilla/OpenWPM/issues/890#issuecomment-820400447? I'd like to open an issue to revert our workaround of keeping `geckodriver` pinned to version `0.26.0` when readthedocs updates its conda version.