### PR TITLE
Fixed default data directory, log directory and log file paths

### DIFF
--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -116,11 +116,11 @@ class ManagerParams(DataClassJsonMixin):
     """
 
     data_directory: Path = field(
-        default=Path("~/openwpm/"),
+        default=Path.home() / "openwpm",
         metadata=DCJConfig(encoder=path_to_str, decoder=str_to_path),
     )
     log_directory: Path = field(
-        default=Path("~/openwpm/"),
+        default=Path.home() / "openwpm",
         metadata=DCJConfig(encoder=path_to_str, decoder=str_to_path),
     )
     log_file: Path = field(


### PR DESCRIPTION
Our default was to create a literal folder called ~ instead of writing to the homedir