### PR TITLE
Save full Firefox profile

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -46,7 +46,7 @@ of configurations of `class<BrowserParams>`.
 - `data_directory`
   - The directory into which screenshots and page dumps will be saved
   - [Intended to be removed by #232](https://github.com/mozilla/OpenWPM/issues/232)
-- `log_directory` -> supported file extensions are `.log`
+- `log_path` -> supported file extensions are `.log`
   - The path to the file in which OpenWPM will log. The
     directory given will be created if it does not exist.
 - `failure_limit` -> has to be either of type `int` or `None`
@@ -287,17 +287,7 @@ browser before visiting the next `site` in `sites`.
 
 ### Loading and saving a browser profile
 
-It's possible to load and save profiles during stateful crawls. Profile dumps
-currently consist of the following browser storage items:
-
-- cookies
-- localStorage
-- IndexedDB
-- browser history
-
-Other browser state, such as the browser cache, is not saved. In
-[Issue #62](https://github.com/citp/OpenWPM/issues/62) we plan to expand
-profiles to include all browser storage.
+It's possible to load and save profiles during stateful crawls.
 
 #### Save a profile
 

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -674,6 +674,7 @@ class BrowserManager(Process):
             with open(ep_filename, "rt") as f:
                 port = int(f.read().strip())
 
+        ep_filename.unlink()
         self.logger.debug(
             "BROWSER %i: Connecting to extension on port %i"
             % (self.browser_params.browser_id, port)


### PR DESCRIPTION
This PR changes [`dump_profile`](https://github.com/mozilla/OpenWPM/blob/dafc26cb562a9d1a7444bb317a12ff69121441a7/openwpm/commands/profile_commands.py#L18L90) so that it saves the whole Firefox profile directory instead of only saving a few of its subcomponents. It also adds a test and expands an existing one in order to test this new feature.

Closes #62.