### PR TITLE
Expand profile tests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-groups: ["test/test_[a-e]*", "test/test_[f-h]*", "test/test_[i-r,t-z]*", "test/test_[s]*", "test/storage/*"]
+        test-groups: ["test/test_[a-e]*", "test/test_[f-h]*", "test/test_[i-o,q-r,t-z]*", "test/test_[p]*", "test/test_[s]*", "test/storage/*"]
       fail-fast: false
     steps:
     # All of these steps are just setup, maybe we should wrap them in an action

--- a/openwpm/commands/profile_commands.py
+++ b/openwpm/commands/profile_commands.py
@@ -105,7 +105,6 @@ class DumpProfileCommand(BaseCommand):
 
 def load_profile(
     browser_profile_path: Path,
-    manager_params: ManagerParamsInternal,
     browser_params: BrowserParamsInternal,
     tar_path: Path,
 ) -> None:

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -56,7 +56,6 @@ def deploy_firefox(
         )
         load_profile(
             browser_profile_path,
-            manager_params,
             browser_params,
             browser_params.seed_tar,
         )
@@ -67,7 +66,6 @@ def deploy_firefox(
         )
         load_profile(
             browser_profile_path,
-            manager_params,
             browser_params,
             browser_params.recovery_tar,
         )

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -189,6 +189,21 @@ def test_load_tar_file(tmp_path):
     assert modified_time_before_load == tar_path.stat().st_mtime
 
 
+def test_crash_during_init(default_params, task_manager_creator):
+    """Test that no profile is saved when Task Manager initialization crashes."""
+    manager_params, browser_params = default_params
+    manager_params.num_browsers = 1
+    browser_params[0].profile_archive_dir = (
+        manager_params.data_directory / "browser_profile"
+    )
+    # This will cause the browser launch to fail
+    browser_params[0].seed_tar = Path("/tmp/NOTREAL")
+    with pytest.raises(ProfileLoadError):
+        manager, _ = task_manager_creator((manager_params, browser_params[:1]))
+    tar_path = browser_params[0].profile_archive_dir / "profile.tar.gz"
+    assert not tar_path.is_file()
+
+
 @pytest.mark.parametrize(
     "seed_tar",
     [None, Path("profile.tar.gz")],

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -205,11 +205,14 @@ def test_crash_during_init(default_params, task_manager_creator):
 
 
 @pytest.mark.parametrize(
-    "seed_tar",
-    [None, Path("profile.tar.gz")],
-    ids=["without_seed_tar", "with_seed_tar"],
+    "stateful,seed_tar",
+    [(True, None), (True, Path("profile.tar.gz")), (False, Path("profile.tar.gz"))],
+    ids=[
+        "stateful-without_seed_tar",
+        "stateful-with_seed_tar",
+        "stateless-with_seed_tar",
+    ],
 )
-@pytest.mark.parametrize("stateful", [True, False], ids=["stateful", "stateless"])
 @pytest.mark.parametrize(
     "testcase",
     ["on_normal_operation", "on_crash", "on_crash_during_launch", "on_timeout"],

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -1,10 +1,13 @@
 import tarfile
+import time
 from pathlib import Path
+from threading import Thread
 from typing import Any
 
 import pytest
 
 from openwpm.command_sequence import CommandSequence
+from openwpm.commands.profile_commands import DumpProfileCommand
 from openwpm.commands.types import BaseCommand
 from openwpm.errors import CommandExecutionError, ProfileLoadError
 from openwpm.utilities import db_utils
@@ -159,3 +162,75 @@ class AssertConfigSetCommand(BaseCommand):
             """
         )
         assert result == self.expected_value
+
+
+@pytest.mark.parametrize(
+    "seed_tar",
+    [None, Path("profile.tar.gz")],
+    ids=["without_seed_tar", "with_seed_tar"],
+)
+@pytest.mark.parametrize("stateful", [True, False], ids=["stateful", "stateless"])
+@pytest.mark.parametrize(
+    "testcase",
+    ["on_normal_operation", "on_crash", "on_crash_during_launch", "on_timeout"],
+)
+# Use -k to run this test for a specific set of parameters. For example:
+# pytest -vv test_profile.py::test_profile_recovery -k on_crash-stateful-with_seed_tar
+def test_profile_recovery(
+    monkeypatch, default_params, task_manager_creator, testcase, stateful, seed_tar
+):
+    """Test browser profile recovery in various scenarios."""
+    manager_params, browser_params = default_params
+    manager_params.num_browsers = 1
+    browser_params[0].seed_tar = seed_tar
+    manager, db = task_manager_creator((manager_params, browser_params[:1]))
+    manager.get(BASE_TEST_URL, reset=not stateful)
+
+    if testcase == "normal_operation":
+        pass
+    elif testcase == "on_crash":
+        # Cause a selenium crash to force browser to restart
+        manager.get("example.com", reset=not stateful)
+    elif testcase == "on_crash_during_launch":
+        # Cause a selenium crash to force browser to restart
+        manager.get("example.com", reset=not stateful)
+        # This will cause browser restarts to fail
+        monkeypatch.setenv("FIREFOX_BINARY", "/tmp/NOTREAL")
+        # Let the launch succeed after some failed launch attempts
+        def undo_monkeypatch():
+            time.sleep(5)  # This should be smaller than _SPAWN_TIMEOUT
+            monkeypatch.undo()
+
+        Thread(target=undo_monkeypatch).start()
+    elif testcase == "on_timeout":
+        # Set a very low timeout to cause a restart
+        manager.get("about:config", reset=not stateful, timeout=0.1)
+
+    cs = CommandSequence("about:config", reset=not stateful)
+    expected_value = True if seed_tar else False
+    cs.append_command(AssertConfigSetCommand("test_pref", expected_value))
+    tar_directory = manager_params.data_directory / "browser_profile"
+    tar_path = tar_directory / "profile.tar.gz"
+    cs.append_command(DumpProfileCommand(tar_path, True))
+    manager.execute_command_sequence(cs)
+    manager.close()
+
+    # Check that a consistent profile is used for stateful crawls but
+    # not for stateless crawls
+    with tarfile.open(tar_path) as tar:
+        tar.extractall(tar_directory)
+    ff_db = tar_directory / "places.sqlite"
+    rows = db_utils.query_db(ff_db, "SELECT url FROM moz_places")
+    places = [url for (url,) in rows]
+    if stateful:
+        assert BASE_TEST_URL in places
+    else:
+        assert BASE_TEST_URL not in places
+
+    # Check if seed_tar was loaded on restart
+    rows = db_utils.query_db(
+        db,
+        "SELECT command_status FROM crawl_history WHERE"
+        " command='AssertConfigSetCommand'",
+    )
+    assert rows[0][0] == "ok"

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -7,7 +7,9 @@ from typing import Any
 import pytest
 
 from openwpm.command_sequence import CommandSequence
+from openwpm.commands.profile_commands import load_profile
 from openwpm.commands.types import BaseCommand
+from openwpm.config import BrowserParamsInternal
 from openwpm.errors import CommandExecutionError, ProfileLoadError
 from openwpm.utilities import db_utils
 
@@ -175,6 +177,16 @@ def test_dump_profile_command(default_params, task_manager_creator):
     manager.execute_command_sequence(cs)
     manager.close()
     assert tar_path.is_file()
+
+
+def test_load_tar_file(tmp_path):
+    """Test that load_profile does not delete or modify the tar file."""
+    tar_path = Path("profile.tar.gz")
+    profile_path = tmp_path / "browser_profile"
+    browser_params = BrowserParamsInternal(browser_id=1)
+    modified_time_before_load = tar_path.stat().st_mtime
+    load_profile(profile_path, browser_params, tar_path)
+    assert modified_time_before_load == tar_path.stat().st_mtime
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR will add more profile tests and eventually close https://github.com/mozilla/OpenWPM/issues/789.

`test_profile_recovery` is a parametrized test that implements the test matrix outlined in https://github.com/mozilla/OpenWPM/issues/789#issuecomment-817924502.

I'll be adding a couple more small tests soon.